### PR TITLE
feat: preserve sibling pane attention

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A WezTerm plugin that turns your tab bar into a notification system. Any CLI too
 | `notify` | ! | Rose | Something needs your attention |
 | `review` | ◆ | Gold | Manually flagged for review |
 
-Inactive tabs light up when a background process writes a marker. Active tabs auto-clear `stop` and `notify` (you've seen it). `thinking` and `review` persist until explicitly removed.
+Tabs light up when a background process writes a marker—even when another pane in that tab is currently focused. Focusing a pane auto-clears only that pane's `stop` and `notify`; markers from unfocused sibling panes remain visible until you visit them. `thinking` and `review` persist until explicitly removed.
 
 When multiple panes in a tab have different states, the highest-priority one wins: **notify > stop > review > thinking**.
 
@@ -97,7 +97,7 @@ attention.apply_to_config(config, {
   -- Priority order (last = highest)
   priority = { "thinking", "review", "stop", "notify" },
 
-  -- Auto-clear these types when switching to the tab
+  -- Auto-clear these types when focusing their pane
   auto_clear = { "stop", "notify" },
 
   -- Stale marker cleanup by type, in milliseconds.
@@ -120,7 +120,7 @@ Any process running inside WezTerm can write a marker. The contract is:
 3. **Optional:** `{"type":"thinking","frame":0}` — `frame` (0-3) controls the spinner position. If omitted for `thinking`, the plugin animates it during polling.
 4. **Optional:** `updated_at` or `updated_at_ms` records when the marker was refreshed. Seconds and milliseconds are both accepted.
 5. **Optional:** `ttl_ms` overrides stale cleanup for that marker. By default, stale `thinking` markers clear after 30 minutes.
-6. **Cleanup** is automatic — markers are removed when panes close, tabs become active, or stale TTL expires
+6. **Cleanup** is automatic — markers are removed when panes close, their panes become focused, or stale TTL expires
 
 The `WEZTERM_PANE` environment variable is injected by WezTerm into every shell it spawns. That's the pane's unique ID.
 

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -34,7 +34,7 @@ local defaults = {
   -- Higher index = higher priority when multiple panes have attention
   priority = { "thinking", "review", "stop", "notify" },
 
-  -- These types auto-clear when their tab becomes active
+  -- These types auto-clear when their pane becomes active
   auto_clear = { "stop", "notify" },
 
   -- Stale marker cleanup by type, in milliseconds. Prevents zombie busy tabs
@@ -104,8 +104,9 @@ local function remove_marker(dir, pane_id)
 end
 
 -- ── In-memory cache ─────────────────────────────────────────────────────────
--- format-tab-title must not do I/O (blocks GUI thread).
--- update-status reads files on the interval; format-tab-title reads cache.
+-- format-tab-title must not poll every pane from disk (it blocks the GUI
+-- thread). update-status fills this cache; auto-clear performs one confirmation
+-- read only when acknowledging a cached terminal marker.
 
 local attention_cache = {} -- { [pane_id_string] = { type = "stop", frame = 0 } }
 
@@ -178,15 +179,33 @@ local function tab_panes_containing(mux_win, pane_id)
   return nil
 end
 
---- Auto-clear applicable markers on an active tab (stop, notify by default).
-local function auto_clear_tab(tab)
+--- Auto-clear an applicable marker on the active pane (stop, notify by default).
+local function auto_clear_active_pane(tab)
   local dir = M._active_dir or defaults.dir
   local clear_set = M._active_clear_set or { stop = true, notify = true }
-  for _, p in ipairs(tab.panes) do
-    local id = tostring(p.pane_id)
-    local cached = attention_cache[id]
-    if cached and clear_set[cached.type] then
+  local pane = tab.active_pane
+  if not pane then return end
+
+  local id = tostring(pane.pane_id)
+  local cached = attention_cache[id]
+  if cached and clear_set[cached.type] then
+    -- Confirm disk truth before a destructive clear. A new turn can replace a
+    -- cached stop with thinking between poll() and this title callback; deleting
+    -- from the stale cache would erase the new lifecycle state.
+    local current_type, current_frame, updated_at, marker_ttl_ms, raw = read_marker(dir, id)
+    if current_type and clear_set[current_type] then
       remove_marker(dir, id)
+      attention_cache[id] = nil
+    elseif current_type then
+      attention_cache[id] = {
+        type        = current_type,
+        frame       = current_frame,
+        updated_at  = updated_at,
+        observed_at = now_ms(),
+        ttl_ms      = marker_ttl_ms,
+        raw         = raw,
+      }
+    else
       attention_cache[id] = nil
     end
   end
@@ -277,6 +296,12 @@ end
 ---   end))
 function M.wrap_title_formatter(base_fn)
   return function(tab, tabs, panes, config, hover, max_width)
+    -- Clear before deriving formatter context so ctx.attention describes only
+    -- attention the user has not seen yet.
+    if tab.is_active then
+      auto_clear_active_pane(tab)
+    end
+
     local ctx = {
       tabs         = tabs,
       panes        = panes,
@@ -287,17 +312,8 @@ function M.wrap_title_formatter(base_fn)
       attention    = { get_tab_attention(tab) },
     }
 
-    -- Auto-clear on active tab
-    if tab.is_active then
-      auto_clear_tab(tab)
-    end
-
     local base = base_fn(tab, ctx)
     local index = tab.tab_index + 1
-
-    if tab.is_active then
-      return " " .. index .. ": " .. base .. " "
-    end
 
     local indicator, atype, color = get_tab_attention(tab)
     local text = " " .. indicator .. index .. ": " .. base .. " "
@@ -385,6 +401,12 @@ function M.apply_to_config(config, opts)
     wezterm.on("format-tab-title", function(tab)
       local index = tab.tab_index + 1
 
+      -- Clear only the pane the user is viewing. Sibling panes may have
+      -- completed in the background and must remain visible on the active tab.
+      if tab.is_active then
+        auto_clear_active_pane(tab)
+      end
+
       -- Build base title (user callback or default)
       local base
       if title_formatter then
@@ -397,13 +419,8 @@ function M.apply_to_config(config, opts)
         base = default_title(tab)
       end
 
-      -- Active tab: auto-clear, plain title
-      if tab.is_active then
-        auto_clear_tab(tab)
-        return " " .. index .. ": " .. base .. " "
-      end
-
-      -- Inactive tab: attention indicator + background tint
+      -- Render any remaining attention, including an unfocused sibling marker
+      -- on the active tab.
       local indicator, attention_type, color = get_tab_attention(tab)
       local text = " " .. indicator .. index .. ": " .. base .. " "
 

--- a/tests/auto_clear_spec.lua
+++ b/tests/auto_clear_spec.lua
@@ -1,0 +1,189 @@
+local source = debug.getinfo(1, "S").source:sub(2)
+local repo_root = source:match("^(.*)/tests/auto_clear_spec.lua$") or "."
+
+local function shell_quote(value)
+  return "'" .. value:gsub("'", "'\\''") .. "'"
+end
+
+local test_dir = os.tmpname()
+os.remove(test_dir)
+assert(os.execute("mkdir -p " .. shell_quote(test_dir)) == 0)
+
+local handlers = {}
+local wezterm = {
+  home_dir = test_dir,
+  action_callback = function(callback) return callback end,
+  json_parse = function(content)
+    return {
+      type = content:match('"type"%s*:%s*"([^"]+)"'),
+      frame = tonumber(content:match('"frame"%s*:%s*(%d+)')),
+      updated_at = tonumber(content:match('"updated_at"%s*:%s*(%d+)')),
+    }
+  end,
+  log_error = function(message)
+    error(message)
+  end,
+  on = function(event, callback)
+    handlers[event] = handlers[event] or {}
+    table.insert(handlers[event], callback)
+  end,
+}
+
+package.preload.wezterm = function() return wezterm end
+
+local attention = dofile(repo_root .. "/plugin/init.lua")
+local config = {}
+attention.apply_to_config(config, {
+  auto_poll = false,
+  dir = test_dir,
+  review_key = false,
+})
+
+local format_tab_title = assert(
+  handlers["format-tab-title"] and handlers["format-tab-title"][1],
+  "format-tab-title handler was not registered"
+)
+
+local function write_marker(pane_id, marker_type)
+  local file = assert(io.open(test_dir .. "/" .. pane_id, "w"))
+  file:write(string.format('{"type":"%s"}', marker_type))
+  file:close()
+end
+
+local function marker_exists(pane_id)
+  local file = io.open(test_dir .. "/" .. pane_id, "r")
+  if not file then return false end
+  file:close()
+  return true
+end
+
+local function mux_pane(pane_id)
+  return {
+    pane_id = function() return pane_id end,
+  }
+end
+
+local function gui_pane(pane_id)
+  return {
+    pane_id = pane_id,
+    title = "pane-" .. pane_id,
+  }
+end
+
+local function poll(pane_ids)
+  local panes = {}
+  for _, pane_id in ipairs(pane_ids) do
+    table.insert(panes, mux_pane(pane_id))
+  end
+
+  local mux_tab = {
+    panes = function() return panes end,
+  }
+  local mux_window = {
+    tabs = function() return { mux_tab } end,
+  }
+  local window = {
+    mux_window = function() return mux_window end,
+  }
+
+  attention.poll(window)
+end
+
+local function tab(active_pane_id, sibling_pane_id, is_active)
+  local active_pane = gui_pane(active_pane_id)
+  local sibling_pane = gui_pane(sibling_pane_id)
+  return {
+    active_pane = active_pane,
+    is_active = is_active,
+    panes = { active_pane, sibling_pane },
+    tab_index = 0,
+  }
+end
+
+local passed = 0
+local failed = 0
+
+local function test(name, callback)
+  local ok, err = pcall(callback)
+  if ok then
+    passed = passed + 1
+    io.write("ok - " .. name .. "\n")
+  else
+    failed = failed + 1
+    io.write("not ok - " .. name .. "\n  " .. tostring(err) .. "\n")
+  end
+end
+
+test("default renderer clears only the focused pane", function()
+  write_marker(101, "stop")
+  write_marker(102, "notify")
+  poll({ 101, 102 })
+
+  local rendered = format_tab_title(tab(101, 102, true))
+
+  assert(not marker_exists(101), "focused pane marker should be cleared")
+  assert(marker_exists(102), "unfocused sibling marker should remain")
+  assert(attention.get_attention(102) == "notify", "sibling cache should remain")
+  assert(type(rendered) == "table", "active tab should render sibling attention styling")
+  assert(rendered[2].Text:find("! ", 1, true), "active tab should show sibling indicator")
+end)
+
+test("manual title wrapper clears only the focused pane", function()
+  write_marker(201, "notify")
+  write_marker(202, "stop")
+  poll({ 201, 202 })
+
+  local formatter_attention
+  local wrapped = attention.wrap_title_formatter(function(_, ctx)
+    formatter_attention = ctx.attention[2]
+    return "custom title"
+  end)
+  local rendered = wrapped(tab(201, 202, true))
+
+  assert(not marker_exists(201), "focused pane marker should be cleared")
+  assert(marker_exists(202), "unfocused sibling marker should remain")
+  assert(type(rendered) == "table", "manual wrapper should render sibling attention styling")
+  assert(rendered[2].Text:find("✓ ", 1, true), "manual wrapper should show sibling indicator")
+  assert(formatter_attention == "stop", "formatter context should reflect retained sibling attention")
+end)
+
+test("inactive tabs do not clear either pane", function()
+  write_marker(301, "stop")
+  write_marker(302, "notify")
+  poll({ 301, 302 })
+
+  format_tab_title(tab(301, 302, false))
+
+  assert(marker_exists(301), "inactive tab active-pane marker should remain")
+  assert(marker_exists(302), "inactive tab sibling marker should remain")
+end)
+
+test("visiting the sibling pane clears its retained marker", function()
+  write_marker(401, "stop")
+  write_marker(402, "notify")
+  poll({ 401, 402 })
+
+  format_tab_title(tab(401, 402, true))
+  assert(marker_exists(402), "unfocused sibling marker should initially remain")
+
+  format_tab_title(tab(402, 401, true))
+  assert(not marker_exists(402), "marker should clear once its pane is focused")
+end)
+
+test("auto-clear never deletes a newer non-clearable marker", function()
+  write_marker(501, "stop")
+  write_marker(502, "notify")
+  poll({ 501, 502 })
+
+  -- A new turn starts after poll() cached stop but before title rendering.
+  write_marker(501, "thinking")
+  format_tab_title(tab(501, 502, true))
+
+  assert(marker_exists(501), "newer thinking marker should remain on disk")
+  assert(attention.get_attention(501) == "thinking", "cache should adopt the newer marker")
+end)
+
+os.execute("rm -rf " .. shell_quote(test_dir))
+
+io.write(string.format("%d passed, %d failed\n", passed, failed))
+if failed > 0 then os.exit(1) end


### PR DESCRIPTION
## Summary

Makes attention acknowledgement pane-scoped for split-pane tabs. Focusing one pane clears only that pane's terminal marker, while completion or notification markers from unfocused siblings remain visible on the active tab until those panes are visited.

The clear path also confirms current disk state before unlinking a marker, preventing a stale cached completion from deleting a newer lifecycle state.

## Key Changes

### Features
- **Pane-scoped acknowledgement**: Clear stop and notify only for tab.active_pane.
- **Visible sibling attention**: Render retained sibling indicators and colors even while their tab is active.
- **Renderer parity**: Apply the same semantics to the built-in formatter and wrap_title_formatter.

### Reliability
- **Race-safe clearing**: Re-read a cached terminal marker before destructive removal and adopt newer non-clearable state into the cache.
- **Contract documentation**: Describe focused-pane clearing and split-pane behavior in the README.

### Tests
- **Lua regression harness**: Exercise default and manual renderers, inactive tabs, pane focus transitions, and stale-cache lifecycle replacement.

## QA checklist

Verified on commit d421fee in a clean detached worktree.

- [x] **Default renderer clears only the focused pane and shows sibling attention** — covered by the focused-pane renderer regression.
- [x] **Manual wrapper clears only the focused pane and exposes retained attention in formatter context** — covered through the public wrapper callback.
- [x] **Inactive tabs retain markers for every pane** — covered by the inactive-tab regression.
- [x] **Visiting a sibling clears its retained terminal marker** — covered by a two-step pane focus transition.
- [x] **A newer thinking marker survives stale cached stop state** — covered by the adversarial lifecycle replacement regression.
- [x] **Plugin remains loadable Lua** — LuaJIT bytecode compilation succeeds.

Fresh automated evidence:

~~~text
luajit tests/auto_clear_spec.lua
ok - default renderer clears only the focused pane
ok - manual title wrapper clears only the focused pane
ok - inactive tabs do not clear either pane
ok - visiting the sibling pane clears its retained marker
ok - auto-clear never deletes a newer non-clearable marker
5 passed, 0 failed

luajit -b plugin/init.lua /tmp/wezterm-attention-init.luac
passed

git diff --check origin/main..HEAD
passed
~~~