### PR TITLE
feat: ship the Pi writer extension from this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,56 @@ wezterm.on("format-tab-title", attention.wrap_title_formatter(function(tab, ctx)
 end))
 ```
 
+## Pi extension
+
+[Pi](https://github.com/badlogic/pi-mono) is an extensible coding agent. This repo ships a Pi extension that writes attention markers for the current WezTerm pane — install it with one command:
+
+```bash
+pi install git:github.com/pro-vi/wezterm-attention
+```
+
+Once installed, it writes markers automatically as Pi works. Outside WezTerm (`WEZTERM_PANE` unset) it's a silent no-op:
+
+| Pi event | Marker | What happens |
+|----------|--------|--------------|
+| `agent_start` | `thinking` | Tab spins violet while Pi runs |
+| `tool_execution_start` | `thinking` | Spinner continues while Pi uses a tool |
+| `agent_end` | `stop` | Tab turns mint with ✓ when Pi finishes |
+
+`thinking` markers carry `ttl_ms`, so a Pi process that exits unexpectedly won't leave a stuck spinner.
+
+### Commands
+
+Control the marker for the current pane manually:
+
+```text
+/attention status              show the current marker
+/attention busy    [label]     mark thinking
+/attention ready   [label]     mark stop
+/attention pending [label]     mark notify (waiting on you)
+/attention blocked [label]     mark notify
+/attention review  [label]     flag for review
+/attention clear               remove the marker
+```
+
+Aliases: `busy → thinking`, `ready → stop`, `pending`/`blocked → notify`. With `WEZTERM_PANE` unset, every command reports that markers are disabled rather than silently doing nothing.
+
+### For other Pi extensions
+
+Any Pi extension can request a marker for the current pane by emitting the shared `wezterm-attention:mark` event — e.g. an ask-user extension flagging `notify` while it waits for you:
+
+```ts
+pi.events.emit("wezterm-attention:mark", { type: "notify" });
+// { type: "clear" } removes it; a bare string like "busy" also works
+```
+
+### Environment
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `WEZTERM_ATTENTION_DIR` | `~/.local/state/wezterm-attention` | Override the marker directory (match the plugin's `dir`) |
+| `PI_WEZTERM_ATTENTION_TTL_MS` | `1800000` (30 min) | Override the `thinking` marker TTL |
+
 ## Claude Code hooks
 
 Claude Code has [hooks](https://docs.anthropic.com/en/docs/claude-code/hooks) that fire on lifecycle events. Add attention markers to each one:

--- a/README.md
+++ b/README.md
@@ -102,7 +102,9 @@ attention.apply_to_config(config, {
 
   -- Stale marker cleanup by type, in milliseconds.
   -- Prevents zombie busy tabs if a process exits without clearing.
-  -- Set to false to disable all stale cleanup.
+  -- Set to false to disable the config-driven sweep. Note: markers that carry
+  -- their own ttl_ms (e.g. the Pi extension's `thinking` markers) still expire
+  -- on that embedded TTL — false only turns off this type-based cleanup.
   stale_after_ms = { thinking = 30 * 60 * 1000 },
 
   -- Review toggle keybind (false to disable)
@@ -122,13 +124,14 @@ Any process running inside WezTerm can write a marker. The contract is:
 5. **Optional:** `ttl_ms` overrides stale cleanup for that marker. By default, stale `thinking` markers clear after 30 minutes.
 6. **Cleanup** is automatic — markers are removed when panes close, their panes become focused, or stale TTL expires
 
-The `WEZTERM_PANE` environment variable is injected by WezTerm into every shell it spawns. That's the pane's unique ID.
+The `WEZTERM_PANE` environment variable is injected by WezTerm into every shell it spawns. That's the pane's unique ID — always a non-negative integer. Validate it (`/^\d+$/`) before building a path from it: a stray `../…` value would otherwise write to, or delete, a file outside the marker directory. Every example and fragment below enforces this.
 
 **Atomic writes recommended:** To avoid partial reads, write to a `.tmp` file then rename:
 
 ### Shell (one-liner)
 
 ```bash
+case "$WEZTERM_PANE" in '' | *[!0-9]*) exit 0 ;; esac  # numeric pane id only
 MARKER_DIR="$HOME/.local/state/wezterm-attention"
 mkdir -p "$MARKER_DIR"
 printf '{"type":"stop","updated_at":%s}\n' "$(date +%s)" > "$MARKER_DIR/$WEZTERM_PANE.tmp" && mv "$MARKER_DIR/$WEZTERM_PANE.tmp" "$MARKER_DIR/$WEZTERM_PANE"
@@ -140,10 +143,13 @@ printf '{"type":"stop","updated_at":%s}\n' "$(date +%s)" > "$MARKER_DIR/$WEZTERM
 import { mkdir, writeFile, rename } from "node:fs/promises";
 import { join } from "node:path";
 
+const pane = process.env.WEZTERM_PANE;
+if (!pane || !/^\d+$/.test(pane)) process.exit(0); // numeric pane id only
+
 const dir = join(process.env.HOME!, ".local", "state", "wezterm-attention");
 await mkdir(dir, { recursive: true });
 
-const file = join(dir, process.env.WEZTERM_PANE!);
+const file = join(dir, pane);
 await writeFile(file + ".tmp", JSON.stringify({ type: "stop", updated_at: Date.now() }));
 await rename(file + ".tmp", file);
 ```
@@ -154,10 +160,13 @@ await rename(file + ".tmp", file);
 const fs = require("fs");
 const path = require("path");
 
+const pane = process.env.WEZTERM_PANE;
+if (!pane || !/^\d+$/.test(pane)) process.exit(0); // numeric pane id only
+
 const dir = path.join(process.env.HOME, ".local", "state", "wezterm-attention");
 fs.mkdirSync(dir, { recursive: true });
 
-const file = path.join(dir, process.env.WEZTERM_PANE);
+const file = path.join(dir, pane);
 fs.writeFileSync(file + ".tmp", JSON.stringify({ type: "stop", updated_at: Date.now() }));
 fs.renameSync(file + ".tmp", file);
 ```
@@ -214,7 +223,9 @@ Once installed, it writes markers automatically from Pi's lifecycle. Outside Wez
 |----------|--------|--------------|
 | `agent_start` | `thinking` | Tab spins violet while Pi runs |
 | `tool_execution_start` | `thinking` | Spinner continues while Pi uses a tool |
-| `agent_end` | `stop` | Tab turns mint with ✓ when Pi finishes |
+| `agent_settled` | `stop` | Tab turns mint with ✓ once Pi is fully done |
+
+`stop` hangs off `agent_settled`, not `agent_end`: `agent_end` fires at the end of every low-level run — including ones Pi will auto-retry or auto-continue after compaction — so using it would flash a false ✓ mid-task. `agent_settled` fires only once Pi will not continue running automatically, so the ✓ appears exactly once, at the real end. (This needs **Pi 0.80.5+** — `agent_settled` landed in the 0.80.4 changelog but 0.80.4 was never published to npm. On an older Pi the extension loads but the ✓ never fires; the spinner clears on its TTL instead.)
 
 `thinking` markers carry `ttl_ms`, so a Pi process that exits unexpectedly won't leave a stuck spinner. That's the whole extension — no commands, no configuration; the tab tracks Pi automatically.
 
@@ -252,6 +263,8 @@ Claude Code has [hooks](https://docs.anthropic.com/en/docs/claude-code/hooks) th
 
 The snippets below are **fragments to paste into your hook files** — not standalone scripts. Each one guards on `WEZTERM_PANE` so it's safe to use outside WezTerm. If you don't have existing hooks, wrap the snippet in a Claude Code hook handler (see [hook docs](https://docs.anthropic.com/en/docs/claude-code/hooks)).
 
+> **Pane-ID contract.** WezTerm sets `WEZTERM_PANE` to a non-negative integer. Every fragment below gates on `/^\d+$/` before touching the filesystem — an unvalidated `../…` value would let a write clobber, or a delete remove, a file *outside* the marker dir.
+
 Register hooks in `~/.claude/settings.json`:
 ```json
 {
@@ -265,7 +278,7 @@ Register hooks in `~/.claude/settings.json`:
 
 **PreToolUse** — animated thinking spinner:
 ```typescript
-if (process.env.WEZTERM_PANE) {
+if (process.env.WEZTERM_PANE && /^\d+$/.test(process.env.WEZTERM_PANE)) {
   const { mkdirSync, writeFileSync, readFileSync, renameSync } = require('fs');
   const markerDir = `${process.env.HOME}/.local/state/wezterm-attention`;
   const markerFile = `${markerDir}/${process.env.WEZTERM_PANE}`;
@@ -284,7 +297,7 @@ if (process.env.WEZTERM_PANE) {
 
 **Stop** — agent finished:
 ```typescript
-if (process.env.WEZTERM_PANE) {
+if (process.env.WEZTERM_PANE && /^\d+$/.test(process.env.WEZTERM_PANE)) {
   const { mkdirSync, writeFileSync, renameSync } = require('fs');
   const markerDir = `${process.env.HOME}/.local/state/wezterm-attention`;
   const markerFile = `${markerDir}/${process.env.WEZTERM_PANE}`;
@@ -296,7 +309,7 @@ if (process.env.WEZTERM_PANE) {
 
 **Notification / PermissionRequest** — needs attention:
 ```typescript
-if (process.env.WEZTERM_PANE) {
+if (process.env.WEZTERM_PANE && /^\d+$/.test(process.env.WEZTERM_PANE)) {
   const { mkdirSync, writeFileSync, renameSync } = require('fs');
   const markerDir = `${process.env.HOME}/.local/state/wezterm-attention`;
   const markerFile = `${markerDir}/${process.env.WEZTERM_PANE}`;
@@ -308,7 +321,7 @@ if (process.env.WEZTERM_PANE) {
 
 **SessionEnd** — cleanup:
 ```typescript
-if (process.env.WEZTERM_PANE) {
+if (process.env.WEZTERM_PANE && /^\d+$/.test(process.env.WEZTERM_PANE)) {
   const { unlinkSync } = require('fs');
   try {
     unlinkSync(`${process.env.HOME}/.local/state/wezterm-attention/${process.env.WEZTERM_PANE}`);
@@ -344,10 +357,16 @@ from the `PreToolUse` / `PermissionRequest` / `Stop` hooks with the matching sta
 async function writeWezTermMarker(marker: Record<string, unknown>): Promise<void> {
   const paneId = process.env.WEZTERM_PANE;
   const home = process.env.HOME;
-  if (!paneId || !home) return;
+  // WezTerm injects WEZTERM_PANE as a non-negative integer. Validate it: a stray
+  // value like "../foo" would escape the marker dir — and on the SessionStart
+  // cleanup path below, the rm would then delete a file outside it.
+  if (!paneId || !home || !/^\d+$/.test(paneId)) return;
 
-  const { mkdir, writeFile, rename } = require("node:fs/promises");
-  const { join } = require("node:path");
+  // `await import`, not `require`: this fragment is ESM-shaped, and bare
+  // `require` is undefined under Node in module mode (throws). `await import`
+  // works under both Node ESM and bun.
+  const { mkdir, writeFile, rename } = await import("node:fs/promises");
+  const { join } = await import("node:path");
 
   const dir = join(home, ".local", "state", "wezterm-attention");
   await mkdir(dir, { recursive: true });
@@ -362,15 +381,16 @@ async function writeWezTermMarker(marker: Record<string, unknown>): Promise<void
 
 Two behaviours the fragment deliberately does **not** implement — wire them in your hooks if you want them:
 
-- **`SessionStart` cleanup** *removes* the marker rather than writing one: `rm(join(dir, paneId), { force: true })`, not `writeWezTermMarker`. (Skip it on the `compact` startup reason so a mid-turn compaction keeps its spinner.)
+- **`SessionStart` cleanup** *removes* the marker rather than writing one: `rm(join(dir, paneId), { force: true })`, not `writeWezTermMarker`. Apply the same `paneId`/`home` guard first (`if (!paneId || !home || !/^\d+$/.test(paneId)) return;`) — the `rm` is the one path where an unvalidated pane id could delete a file *outside* the marker dir. (Skip cleanup on the `compact` startup reason so a mid-turn compaction keeps its spinner.)
 - **Spinner frame cycling** (`frame` 0→3 across repeated `PreToolUse`) needs reading the current marker and incrementing; omit it entirely and the plugin animates the spinner on its own poll. Optional.
 
 (`updated_at_ms` is accepted by the plugin alongside `updated_at`.)
 
-**Coverage caveat.** `PermissionRequest` fires only for command / patch / network approvals — *not*
-for Codex's other human-input waits (`request_user_input`, `request_permissions`, and MCP
-elicitation). A turn blocked on one of those shows the `thinking` spinner, not `!`. Routing those to
-`notify` means detecting the tool in `PreToolUse`; it isn't wired here yet.
+**Coverage caveat.** `PermissionRequest` fires for command / patch / network approvals *and* MCP
+tool-call approvals — but *not* for Codex's other human-input waits (`request_user_input`,
+`request_permissions`, and MCP *elicitation*). A turn blocked on one of those uncovered waits shows
+the `thinking` spinner, not `!`. Routing those to `notify` means detecting the tool in `PreToolUse`;
+it isn't wired here yet.
 
 ## Other use cases
 

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ end))
 pi install git:github.com/pro-vi/wezterm-attention
 ```
 
-Once installed, it writes markers automatically as Pi works. Outside WezTerm (`WEZTERM_PANE` unset) it's a silent no-op:
+Once installed, it writes markers automatically from Pi's lifecycle. Outside WezTerm (`WEZTERM_PANE` unset) it's a silent no-op:
 
 | Pi event | Marker | What happens |
 |----------|--------|--------------|
@@ -216,32 +216,18 @@ Once installed, it writes markers automatically as Pi works. Outside WezTerm (`W
 | `tool_execution_start` | `thinking` | Spinner continues while Pi uses a tool |
 | `agent_end` | `stop` | Tab turns mint with ✓ when Pi finishes |
 
-`thinking` markers carry `ttl_ms`, so a Pi process that exits unexpectedly won't leave a stuck spinner.
+`thinking` markers carry `ttl_ms`, so a Pi process that exits unexpectedly won't leave a stuck spinner. That's the whole extension — no commands, no configuration; the tab tracks Pi automatically.
 
-### Commands
+### The `notify` state, for other extensions
 
-Control the marker for the current pane manually:
-
-```text
-/attention status              show the current marker
-/attention busy    [label]     mark thinking
-/attention ready   [label]     mark stop
-/attention pending [label]     mark notify (waiting on you)
-/attention blocked [label]     mark notify
-/attention review  [label]     flag for review
-/attention clear               remove the marker
-```
-
-Aliases: `busy → thinking`, `ready → stop`, `pending`/`blocked → notify`. With `WEZTERM_PANE` unset, every command reports that markers are disabled rather than silently doing nothing.
-
-### For other Pi extensions
-
-Any Pi extension can request a marker for the current pane by emitting the shared `wezterm-attention:mark` event — e.g. an ask-user extension flagging `notify` while it waits for you:
+Pi's lifecycle only produces `thinking` and `stop` — there's no lifecycle event for "blocked, waiting for a human", so the extension never raises the rose `!` on its own. Instead it listens on a shared event bus so **any other Pi extension can request a state** without knowing anything about marker files or `WEZTERM_PANE`. The typical caller is an ask-user extension flagging `notify` while it waits for you, then clearing it:
 
 ```ts
-pi.events.emit("wezterm-attention:mark", { type: "notify" });
-// { type: "clear" } removes it; a bare string like "busy" also works
+pi.events.emit("wezterm-attention:mark", { type: "notify" }); // waiting on you → rose !
+pi.events.emit("wezterm-attention:mark", { type: "clear" });  // answered → remove it
 ```
+
+The payload is a bare string (`"notify"`) or an object (`{ type: "notify", label }`); accepted states are `thinking` / `stop` / `notify` / `review` / `clear` (with `busy`, `ready`, `pending`, `blocked` as aliases). Extensions that would rather not depend on this event can always [write the marker file directly](#the-protocol).
 
 ### Environment
 

--- a/README.md
+++ b/README.md
@@ -334,21 +334,25 @@ if (process.env.WEZTERM_PANE) {
 
 ## Codex hooks
 
-Wire Codex through its **lifecycle hooks** (`~/.codex/hooks.json`). Avoid the older
-`~/.codex/config.toml` `[hooks] notify` field: it is finish-only, and the desktop Codex "Computer
-Use" app silently rewrites it on launch (repointing it at a temp path that later disappears), so
-markers quietly stop firing. Lifecycle hooks aren't touched by that. They require a one-time trust
-step — run `/hooks` in Codex and approve them once per machine before they fire.
+Wire Codex through its **lifecycle hooks** (`~/.codex/hooks.json`). Avoid the older top-level
+`notify` field in `~/.codex/config.toml`: it is finish-only, and the desktop Codex "Computer Use"
+app silently rewrites it on launch (repointing it at a temp path that later disappears), so markers
+quietly stop firing. Lifecycle hooks aren't touched by that. They require a one-time trust approval —
+run `/hooks` in Codex and approve — and because trust is keyed to a hash of the hook definition,
+editing a hook re-prompts. See the [Codex hooks documentation](https://learn.chatgpt.com/docs/hooks)
+for the `hooks.json` schema that binds each event to a command.
 
-The marker writer is transport-agnostic — it writes the same JSON the plugin reads, tagged
-`source:"codex"`. Map each lifecycle event to the matching state:
+Map each lifecycle event to a marker state (all tagged `source:"codex"`):
 
-| Codex lifecycle event | Marker |
+| Codex lifecycle event | Marker state |
 |---|---|
-| `PreToolUse` | `{"type":"thinking","source":"codex","frame":0-3,"updated_at_ms":…}` (frame cycles 0→3) |
-| `PermissionRequest` | `{"type":"notify","source":"codex","updated_at_ms":…}` |
-| `Stop` | `{"type":"stop","source":"codex","updated_at_ms":…}` |
-| `SessionStart` | clears the marker (skip `compact`, so a mid-turn compaction keeps its spinner) |
+| `PreToolUse` | `thinking` (optionally cycle `frame` 0→3 for the spinner) |
+| `PermissionRequest` | `notify` |
+| `Stop` | `stop` |
+| `SessionStart` | **remove** the marker file |
+
+The three *write* states share one helper — a **writer-only fragment**, not a complete hook. Call it
+from the `PreToolUse` / `PermissionRequest` / `Stop` hooks with the matching state:
 
 ```typescript
 async function writeWezTermMarker(marker: Record<string, unknown>): Promise<void> {
@@ -365,11 +369,17 @@ async function writeWezTermMarker(marker: Record<string, unknown>): Promise<void
   await writeFile(file + ".tmp", JSON.stringify({ source: "codex", updated_at_ms: Date.now(), ...marker }));
   await rename(file + ".tmp", file); // atomic
 }
+// PreToolUse:        writeWezTermMarker({ type: "thinking" })
+// PermissionRequest: writeWezTermMarker({ type: "notify" })
+// Stop:              writeWezTermMarker({ type: "stop" })
 ```
 
-See Codex's hooks documentation for the `hooks.json` structure that binds each lifecycle event to a
-command; call `writeWezTermMarker` from each with the state above. (`updated_at_ms` is accepted by
-the plugin alongside `updated_at`.)
+Two behaviours the fragment deliberately does **not** implement — wire them in your hooks if you want them:
+
+- **`SessionStart` cleanup** *removes* the marker rather than writing one: `rm(join(dir, paneId), { force: true })`, not `writeWezTermMarker`. (Skip it on the `compact` startup reason so a mid-turn compaction keeps its spinner.)
+- **Spinner frame cycling** (`frame` 0→3 across repeated `PreToolUse`) needs reading the current marker and incrementing; omit it entirely and the plugin animates the spinner on its own poll. Optional.
+
+(`updated_at_ms` is accepted by the plugin alongside `updated_at`.)
 
 **Coverage caveat.** `PermissionRequest` fires only for command / patch / network approvals — *not*
 for Codex's other human-input waits (`request_user_input`, `request_permissions`, and MCP

--- a/README.md
+++ b/README.md
@@ -334,34 +334,47 @@ if (process.env.WEZTERM_PANE) {
 
 ## Codex hooks
 
-Codex uses a single `notify` hook that fires when the agent finishes or needs attention. Add this to your Codex notify handler:
+Wire Codex through its **lifecycle hooks** (`~/.codex/hooks.json`). Avoid the older
+`~/.codex/config.toml` `[hooks] notify` field: it is finish-only, and the desktop Codex "Computer
+Use" app silently rewrites it on launch (repointing it at a temp path that later disappears), so
+markers quietly stop firing. Lifecycle hooks aren't touched by that. They require a one-time trust
+step — run `/hooks` in Codex and approve them once per machine before they fire.
+
+The marker writer is transport-agnostic — it writes the same JSON the plugin reads, tagged
+`source:"codex"`. Map each lifecycle event to the matching state:
+
+| Codex lifecycle event | Marker |
+|---|---|
+| `PreToolUse` | `{"type":"thinking","source":"codex","frame":0-3,"updated_at_ms":…}` (frame cycles 0→3) |
+| `PermissionRequest` | `{"type":"notify","source":"codex","updated_at_ms":…}` |
+| `Stop` | `{"type":"stop","source":"codex","updated_at_ms":…}` |
+| `SessionStart` | clears the marker (skip `compact`, so a mid-turn compaction keeps its spinner) |
 
 ```typescript
-async function writeWezTermMarker(type: "stop" | "notify"): Promise<void> {
+async function writeWezTermMarker(marker: Record<string, unknown>): Promise<void> {
   const paneId = process.env.WEZTERM_PANE;
   const home = process.env.HOME;
   if (!paneId || !home) return;
 
-  const { mkdir, writeFile } = require("node:fs/promises");
+  const { mkdir, writeFile, rename } = require("node:fs/promises");
   const { join } = require("node:path");
 
-  const markerDir = join(home, ".local", "state", "wezterm-attention");
-  await mkdir(markerDir, { recursive: true });
-  await writeFile(join(markerDir, paneId), JSON.stringify({ type, updated_at: Date.now() }));
+  const dir = join(home, ".local", "state", "wezterm-attention");
+  await mkdir(dir, { recursive: true });
+  const file = join(dir, paneId);
+  await writeFile(file + ".tmp", JSON.stringify({ source: "codex", updated_at_ms: Date.now(), ...marker }));
+  await rename(file + ".tmp", file); // atomic
 }
-
-// In your notify handler:
-// - "stop" if the agent completed work (has last-assistant-message)
-// - "notify" for other notifications
-const attentionType = payload["last-assistant-message"] ? "stop" : "notify";
-await writeWezTermMarker(attentionType);
 ```
 
-Wire it in `~/.codex/config.toml`:
-```toml
-[hooks]
-notify = ["bun", "/path/to/your/notify.ts"]
-```
+See Codex's hooks documentation for the `hooks.json` structure that binds each lifecycle event to a
+command; call `writeWezTermMarker` from each with the state above. (`updated_at_ms` is accepted by
+the plugin alongside `updated_at`.)
+
+**Coverage caveat.** `PermissionRequest` fires only for command / patch / network approvals — *not*
+for Codex's other human-input waits (`request_user_input`, `request_permissions`, and MCP
+elicitation). A turn blocked on one of those shows the `thinking` spinner, not `!`. Routing those to
+`notify` means detecting the tool in `PreToolUse`; it isn't wired here yet.
 
 ## Other use cases
 

--- a/examples/hook.sh
+++ b/examples/hook.sh
@@ -3,6 +3,12 @@
 # Shell one-liner to write an attention marker.
 # Drop this into any hook or script that runs inside WezTerm.
 
+# WEZTERM_PANE is a non-negative integer set by WezTerm; bail if it's unset or
+# malformed so a stray value can't build a path outside the marker directory.
+case "$WEZTERM_PANE" in
+  '' | *[!0-9]*) exit 0 ;;
+esac
+
 MARKER_DIR="${HOME}/.local/state/wezterm-attention"
 mkdir -p "$MARKER_DIR"
 

--- a/examples/hook.ts
+++ b/examples/hook.ts
@@ -19,7 +19,9 @@ type AttentionType = "thinking" | "stop" | "notify" | "review";
 async function writeMarker(type: AttentionType, frame?: number): Promise<void> {
   const paneId = process.env.WEZTERM_PANE;
   const home = process.env.HOME;
-  if (!paneId || !home) return;
+  // WezTerm sets WEZTERM_PANE to a non-negative integer; validate it so a stray
+  // value can't build a path outside the marker directory.
+  if (!paneId || !home || !/^\d+$/.test(paneId)) return;
 
   const dir = join(home, ".local", "state", "wezterm-attention");
   await mkdir(dir, { recursive: true });

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "wezterm-attention",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "keywords": ["pi-package"],
+  "pi": {
+    "extensions": ["./pi/index.ts"]
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "*"
+  },
+  "peerDependenciesMeta": {
+    "@earendil-works/pi-coding-agent": {
+      "optional": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "extensions": ["./pi/index.ts"]
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "*"
+    "@earendil-works/pi-coding-agent": ">=0.80.5"
   },
   "peerDependenciesMeta": {
     "@earendil-works/pi-coding-agent": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "1.0.0",
   "type": "module",
+  "scripts": {
+    "test": "bun test"
+  },
   "keywords": ["pi-package"],
   "pi": {
     "extensions": ["./pi/index.ts"]

--- a/pi/index.ts
+++ b/pi/index.ts
@@ -221,12 +221,30 @@ export default function weztermAttentionPiExtension(pi: ExtensionAPI): void {
 	// Automatic: Pi lifecycle → WezTerm tab state. Lifecycle handlers are stored
 	// per-extension-instance by Pi's runner and replaced wholesale on reload, so
 	// they don't accumulate — safe to register on every load.
-	pi.on("agent_start", async () => {
-		await mark("thinking");
+	// These do NOT await the write. Pi awaits lifecycle handlers on the agent's own
+	// critical path — agent-loop.ts emits `tool_execution_start` and awaits it before
+	// preparing the tool call, through agent.ts's serial `await listener(...)` and
+	// agent-session.ts's `await this._emitExtensionEvent(event)`, down to runner.ts's
+	// `await handler(event, ctx)`. None of those has a timeout. So awaiting a marker
+	// write here puts the filesystem inside the agent's latency budget, and on a mount
+	// whose syscalls block indefinitely (hard NFS/SMB, dead FUSE daemon) it wedges the
+	// host outright: every write shares one serial chain, so a single stuck op parks
+	// every later lifecycle event too, the TUI never sees the event (the notify at
+	// agent-session.ts:601 is downstream of the await), and aborting does not release
+	// an already-parked await. Headless is worse — `_resolveIdleWaitIfIdle()` sits in a
+	// `finally` whose `try` awaits this emit, so `pi -p` never terminates.
+	//
+	// A tab tint is best-effort; the host's liveness is not ours to spend. Ordering is
+	// unaffected: `enqueue` chains synchronously at call time, so emit order == apply
+	// order is a property of CALL order, not await order. The session_shutdown drain is
+	// what guarantees these land before a reload — which makes that drain load-bearing
+	// in a way it was not before. Do not weaken it.
+	pi.on("agent_start", () => {
+		void mark("thinking").catch(() => {});
 	});
 
-	pi.on("tool_execution_start", async () => {
-		await mark("thinking");
+	pi.on("tool_execution_start", () => {
+		void mark("thinking").catch(() => {});
 	});
 
 	// `agent_settled`, NOT `agent_end`: agent_end fires at the end of every
@@ -234,8 +252,8 @@ export default function weztermAttentionPiExtension(pi: ExtensionAPI): void {
 	// continue with queued follow-up messages — writing `stop` there flashes a
 	// false ✓ mid-task. agent_settled fires only once Pi will not continue
 	// running automatically. Requires Pi >= 0.80.5.
-	pi.on("agent_settled", async () => {
-		await mark("stop");
+	pi.on("agent_settled", () => {
+		void mark("stop").catch(() => {});
 	});
 
 	// Cooperative: any other Pi extension (e.g. an ask-user extension) can emit

--- a/pi/index.ts
+++ b/pi/index.ts
@@ -6,7 +6,10 @@ import { isAbsolute, join } from "node:path";
 const DEFAULT_TTL_MS = 30 * 60 * 1000;
 const ATTENTION_EVENT = "wezterm-attention:mark";
 // Cap the session_shutdown drain so a hung marker FS can never wedge Pi's reload
-// or quit. Normal writes settle in single-digit ms; this is only a safety valve.
+// or quit. Measured p99 for one write is well under a millisecond, so this is
+// only a safety valve — but note it bounds the WHOLE queued backlog, not a single
+// write: the drain awaits the tail of the serial chain, so N queued writes trip
+// it once their SUM exceeds the cap, even though no individual write is slow.
 const DRAIN_TIMEOUT_MS = 2000;
 
 type AttentionState = "thinking" | "stop" | "notify" | "review";
@@ -23,9 +26,14 @@ type Marker = {
 // degenerate-env holes: WEZTERM_ATTENTION_DIR="" would otherwise leave the clear
 // path calling rm() on a cwd-relative name (deleting a file where Pi was
 // launched), and HOME="" resolves to a relative ".local/..." that scatters
-// markers into the launch directory where the plugin never looks. `||` (not
-// `??`) folds an empty override or empty HOME into the fallback; the isAbsolute
-// gate rejects any still-relative result so the caller no-ops.
+// markers into the launch directory where the plugin never looks.
+//
+// The two operators do NOT split that work evenly. `||` (not `??`) matters only
+// for the override: with `||` an empty WEZTERM_ATTENTION_DIR falls through to the
+// HOME-based default and markers are still written, where `??` would keep "" and
+// no-op everything. For HOME it changes nothing — os.homedir() also returns ""
+// when HOME="" — so the isAbsolute gate below is what actually closes that hole.
+// Do not remove it on the assumption that `||` covers HOME; it does not.
 function markerDirectory(): string | undefined {
 	const dir = process.env.WEZTERM_ATTENTION_DIR || join(process.env.HOME || homedir(), ".local", "state", "wezterm-attention");
 	return isAbsolute(dir) ? dir : undefined;
@@ -256,8 +264,22 @@ export default function weztermAttentionPiExtension(pi: ExtensionAPI): void {
 	// with no successor.
 	//
 	// The drain is bounded: Pi awaits this handler with no timeout of its own, so
-	// a hung marker FS must never wedge /reload or quit. Markers are best-effort;
-	// capping the wait matches that contract.
+	// a hung marker FS must never wedge /reload or quit.
+	//
+	// Be precise about what the cap trades away. Timing out does NOT cancel the
+	// abandoned write — it is still in flight, and it can land AFTER the next
+	// generation has written, leaving the older state on disk (e.g. a stale
+	// `thinking` overwriting a fresh `stop`, which the plugin then renders until
+	// the next event or the marker's own ttl_ms expires). So the cap converts
+	// "reload hangs" into "marker may be briefly wrong", which is the right trade
+	// for a best-effort indicator, but it is a different failure, not no failure.
+	// Reachable only on /reload and the /new,/fork,/resume teardowns (quit exits
+	// the process immediately), and only when the queued backlog exceeds the cap.
+	//
+	// Do NOT "fix" this with a sticky abandoned flag that suppresses later writes:
+	// a generation survives a *failed* reload by design (see above and the
+	// failed-reload test), so one timeout plus one failed reload would silence the
+	// extension permanently. Gate on a per-operation generation counter instead.
 	pi.on("session_shutdown", async () => {
 		let timer: ReturnType<typeof setTimeout> | undefined;
 		await Promise.race([

--- a/pi/index.ts
+++ b/pi/index.ts
@@ -276,9 +276,26 @@ export default function weztermAttentionPiExtension(pi: ExtensionAPI): void {
 	//
 	// The cap does not cancel an abandoned write; it can land after the next
 	// generation's write and leave stale state until the next event or the marker's
-	// ttl_ms. Accepted trade for a best-effort indicator. Do not "fix" it with a
-	// sticky abandoned flag — one failed reload turns that into permanent silence;
-	// use a per-operation generation counter if it ever matters.
+	// ttl_ms. Accepted trade for a best-effort indicator.
+	//
+	// Three fixes look obvious here and all three are worse than the defect:
+	//
+	// - A sticky abandoned flag: a generation survives a *failed* reload by design,
+	//   so one timeout plus one failed reload is permanent silence.
+	// - Sharing the chain across generations (proposed independently twice, so expect
+	//   it again): the host awaits lifecycle handlers all the way from the agent loop,
+	//   so a successor inheriting a stuck predecessor's backlog stalls the agent's own
+	//   run — measured as a block equal to the whole abandoned backlog, and on a
+	//   stalled mount a permanent wedge with no marker ever written again. The cap is
+	//   not an oversight to delete; it is what keeps a stuck fs op away from the host.
+	// - A per-operation generation counter: closes the queued-backlog case but NOT a
+	//   single write that stalls inside `rename` past the cap, because the gate
+	//   necessarily precedes the publish. Verified: the successor registers while the
+	//   rename is still in flight, then the rename lands and clobbers.
+	//
+	// Closing the remaining case needs the bus-owned controller — one controller per
+	// bus owning the listener and the mutation state, re-asserting the last requested
+	// state after an abandoned write lands. Deferred; its trigger has not arrived.
 	pi.on("session_shutdown", async () => {
 		let timer: ReturnType<typeof setTimeout> | undefined;
 		await Promise.race([

--- a/pi/index.ts
+++ b/pi/index.ts
@@ -275,8 +275,24 @@ export default function weztermAttentionPiExtension(pi: ExtensionAPI): void {
 	// leave us silenced with no successor.
 	//
 	// The cap does not cancel an abandoned write; it can land after the next
-	// generation's write and leave stale state until the next event or the marker's
-	// ttl_ms. Accepted trade for a best-effort indicator.
+	// generation's write and leave stale state. A stale *write* self-limits — the
+	// next event overwrites it, or its ttl_ms expires it. Same residual, same fix,
+	// for an op enqueued AFTER this race snapshots the chain — e.g. a later extension
+	// emitting `clear` on the bus during its own session_shutdown, which our still-live
+	// listener enqueues past the snapshot, so the cap never sees it. Note a late
+	// `clear` REMOVES the successor's marker, and ttl_ms cannot self-heal an absent
+	// file — only a later lifecycle/event write restores it. Accepted trade for a
+	// best-effort indicator.
+	//
+	// Second accepted cost under a *permanently* blocked write (dead NFS/SMB/FUSE
+	// mount, not a merely slow one): the serial chain retains every op queued behind
+	// the stuck head, because a real in-flight fs op is rooted by libuv and holds its
+	// forward reaction chain (each op captures its marker + label). Measured ~0.6 KB
+	// per queued op — unbounded until the mount recovers or the process restarts, on
+	// the same rare precondition as the clobber above. NOT worth a coalescing mailbox:
+	// that bounds memory but breaks the FIFO ordering the tests lock, dropping
+	// intermediate states — the bus-owned controller below is the right home if it
+	// ever earns its trigger.
 	//
 	// Three fixes look obvious here and all three are worse than the defect:
 	//

--- a/pi/index.ts
+++ b/pi/index.ts
@@ -1,5 +1,5 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { mkdir, rename, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -7,12 +7,6 @@ const DEFAULT_TTL_MS = 30 * 60 * 1000;
 const ATTENTION_EVENT = "wezterm-attention:mark";
 
 type AttentionState = "thinking" | "stop" | "notify" | "review";
-type AttentionCommand = "busy" | "thinking" | "ready" | "stop" | "blocked" | "pending" | "notify" | "review" | "clear" | "status";
-
-// Outcome of a marker mutation. Distinguishes "no pane" from "bad pane" from an
-// actual filesystem failure so callers can report the true reason rather than
-// collapsing every failure into "WEZTERM_PANE is not set".
-type MarkOutcome = "ok" | "missing-pane" | "invalid-pane" | "io-error";
 
 type Marker = {
 	type: AttentionState;
@@ -22,29 +16,17 @@ type Marker = {
 	ttl_ms?: number;
 };
 
-const COMMANDS: Array<{ value: AttentionCommand; description: string }> = [
-	{ value: "busy", description: "Mark this pane as thinking" },
-	{ value: "ready", description: "Mark this pane as done" },
-	{ value: "pending", description: "Alias for notify; mark this pane as waiting for human input" },
-	{ value: "blocked", description: "Alias for notify" },
-	{ value: "review", description: "Mark this pane for manual review" },
-	{ value: "clear", description: "Clear this pane's attention marker" },
-	{ value: "status", description: "Show current marker state" },
-];
-
 function markerDirectory(): string {
 	return process.env.WEZTERM_ATTENTION_DIR ?? join(process.env.HOME ?? homedir(), ".local", "state", "wezterm-attention");
 }
 
 // WezTerm injects WEZTERM_PANE as a non-negative integer pane id. Validate the
-// contract before building a path: an unvalidated value like "../../foo" would
-// escape the marker directory, and clearMarker's rm would then delete an
-// arbitrary file. Reject anything that is not purely digits.
-function readPaneId(): { ok: true; id: string } | { ok: false; reason: "missing-pane" | "invalid-pane" } {
+// contract: an unvalidated value like "../../foo" would escape the marker
+// directory, and clearMarker's rm could then delete an arbitrary file.
+function paneId(): string | undefined {
 	const id = process.env.WEZTERM_PANE;
-	if (!id) return { ok: false, reason: "missing-pane" };
-	if (!/^\d+$/.test(id)) return { ok: false, reason: "invalid-pane" };
-	return { ok: true, id };
+	if (!id || !/^\d+$/.test(id)) return undefined;
+	return id;
 }
 
 function ttlMs(): number {
@@ -54,8 +36,10 @@ function ttlMs(): number {
 	return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_TTL_MS;
 }
 
-function normalizeCommand(command: string): AttentionState | "clear" | "status" | undefined {
-	switch (command) {
+// Maps the states other extensions may request over the event bus (including a
+// few friendly aliases) to a canonical marker state, or "clear".
+function normalizeState(value: string): AttentionState | "clear" | undefined {
+	switch (value) {
 		case "busy":
 		case "thinking":
 			return "thinking";
@@ -70,21 +54,18 @@ function normalizeCommand(command: string): AttentionState | "clear" | "status" 
 			return "review";
 		case "clear":
 			return "clear";
-		case "status":
-		case "":
-			return "status";
 		default:
 			return undefined;
 	}
 }
 
-// All marker mutations (and status reads) run through this single serial chain,
-// so emit order equals apply order even for the fire-and-forget event-bus path.
-// Without it, a `notify` immediately followed by `clear` races: rm finishes
-// before the write's rename, leaving the marker present. The chain swallows
-// results so one failure never poisons later operations.
+// All mutations run through one serial chain so emit order == apply order even
+// for the fire-and-forget event path: a `notify` immediately followed by a
+// `clear` must not race (rm finishing before the write's rename would leave the
+// marker present). The chain swallows results so one failure never poisons later
+// operations.
 let mutationChain: Promise<unknown> = Promise.resolve();
-function enqueue<T>(op: () => Promise<T>): Promise<T> {
+function enqueue(op: () => Promise<void>): Promise<void> {
 	const run = mutationChain.then(op, op);
 	mutationChain = run.then(
 		() => undefined,
@@ -93,17 +74,17 @@ function enqueue<T>(op: () => Promise<T>): Promise<T> {
 	return run;
 }
 
-// Monotonic counter makes temp filenames unique within the process even for
+// Monotonic counter keeps temp filenames unique within the process even for
 // same-millisecond writes; serialization already prevents overlap, this is
 // defense in depth.
 let tmpSeq = 0;
 
-async function writeMarkerNow(state: AttentionState, label?: string): Promise<MarkOutcome> {
-	const pane = readPaneId();
-	if (!pane.ok) return pane.reason;
+async function writeMarkerNow(state: AttentionState, label?: string): Promise<void> {
+	const id = paneId();
+	if (!id) return;
 
 	const dir = markerDirectory();
-	const path = join(dir, pane.id);
+	const path = join(dir, id);
 	const marker: Marker = {
 		type: state,
 		source: "pi",
@@ -117,73 +98,27 @@ async function writeMarkerNow(state: AttentionState, label?: string): Promise<Ma
 		const tmp = `${path}.tmp.${process.pid}.${Date.now()}.${tmpSeq++}`;
 		await writeFile(tmp, JSON.stringify(marker) + "\n");
 		await rename(tmp, path);
-		return "ok";
 	} catch {
-		return "io-error";
+		// Best-effort: a marker that fails to write just means the tab doesn't change.
 	}
 }
 
-async function clearMarkerNow(): Promise<MarkOutcome> {
-	const pane = readPaneId();
-	if (!pane.ok) return pane.reason;
+async function clearMarkerNow(): Promise<void> {
+	const id = paneId();
+	if (!id) return;
 	try {
-		await rm(join(markerDirectory(), pane.id), { force: true });
-		return "ok";
+		await rm(join(markerDirectory(), id), { force: true });
 	} catch {
-		return "io-error";
+		// Best-effort.
 	}
 }
 
-function writeMarker(state: AttentionState, label?: string): Promise<MarkOutcome> {
+function mark(state: AttentionState, label?: string): Promise<void> {
 	return enqueue(() => writeMarkerNow(state, label));
 }
 
-function clearMarker(): Promise<MarkOutcome> {
+function clearMarker(): Promise<void> {
 	return enqueue(() => clearMarkerNow());
-}
-
-// Read behind the mutation chain so `status` reflects the latest queued write or
-// clear rather than a stale on-disk state.
-async function readMarkerText(): Promise<string | undefined> {
-	const pane = readPaneId();
-	if (!pane.ok) return undefined;
-	return enqueue(async () => {
-		try {
-			return await readFile(join(markerDirectory(), pane.id), "utf8");
-		} catch {
-			return undefined;
-		}
-	});
-}
-
-async function mark(state: AttentionState, label?: string): Promise<MarkOutcome> {
-	return writeMarker(state, label);
-}
-
-function writeMessage(outcome: MarkOutcome, command: string): { text: string; level: "info" | "warning" } {
-	switch (outcome) {
-		case "ok":
-			return { text: `Marked WezTerm pane as ${command}`, level: "info" };
-		case "missing-pane":
-			return { text: "WEZTERM_PANE is not set; nothing written", level: "info" };
-		case "invalid-pane":
-			return { text: "WEZTERM_PANE is not a valid pane id; nothing written", level: "warning" };
-		case "io-error":
-			return { text: "Failed to write WezTerm marker (I/O error)", level: "warning" };
-	}
-}
-
-function clearMessage(outcome: MarkOutcome): { text: string; level: "info" | "warning" } {
-	switch (outcome) {
-		case "ok":
-			return { text: "Cleared WezTerm attention marker", level: "info" };
-		case "missing-pane":
-			return { text: "WEZTERM_PANE is not set; nothing to clear", level: "info" };
-		case "invalid-pane":
-			return { text: "WEZTERM_PANE is not a valid pane id; nothing to clear", level: "warning" };
-		case "io-error":
-			return { text: "Failed to clear WezTerm marker (I/O error)", level: "warning" };
-	}
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -194,34 +129,26 @@ function stringFromUnknown(value: unknown): string | undefined {
 	return typeof value === "string" ? value : undefined;
 }
 
+// Accepts a bare string ("notify") or an object ({ type | state | command, label }).
 function normalizeEventData(data: unknown): { state: AttentionState | "clear"; label?: string } | undefined {
 	if (typeof data === "string") {
-		const state = normalizeCommand(data);
-		return state && state !== "status" ? { state } : undefined;
+		const state = normalizeState(data);
+		return state ? { state } : undefined;
 	}
 	if (!isRecord(data)) return undefined;
 
-	const rawState = stringFromUnknown(data.state) ?? stringFromUnknown(data.type) ?? stringFromUnknown(data.command);
-	if (!rawState) return undefined;
+	const raw = stringFromUnknown(data.state) ?? stringFromUnknown(data.type) ?? stringFromUnknown(data.command);
+	if (!raw) return undefined;
 
-	const state = normalizeCommand(rawState);
-	if (!state || state === "status") return undefined;
+	const state = normalizeState(raw);
+	if (!state) return undefined;
 
 	const label = stringFromUnknown(data.label);
 	return { state, ...(label ? { label } : {}) };
 }
 
 export default function weztermAttentionPiExtension(pi: ExtensionAPI): void {
-	pi.events.on(ATTENTION_EVENT, (data) => {
-		const request = normalizeEventData(data);
-		if (!request) return;
-		if (request.state === "clear") {
-			void clearMarker();
-			return;
-		}
-		void mark(request.state, request.label);
-	});
-
+	// Automatic: Pi lifecycle → WezTerm tab state. These produce thinking/stop only.
 	pi.on("agent_start", async () => {
 		await mark("thinking");
 	});
@@ -234,50 +161,17 @@ export default function weztermAttentionPiExtension(pi: ExtensionAPI): void {
 		await mark("stop");
 	});
 
-	pi.registerCommand("attention", {
-		description: "Control the WezTerm attention marker for this Pi pane",
-		getArgumentCompletions: (prefix) => {
-			const normalizedPrefix = prefix.trim().toLowerCase();
-			return COMMANDS.filter((command) => command.value.startsWith(normalizedPrefix)).map((command) => ({
-				value: command.value,
-				label: command.value,
-				description: command.description,
-			}));
-		},
-		handler: async (args, ctx) => {
-			const [rawCommand = "status", ...labelParts] = args.trim().split(/\s+/).filter(Boolean);
-			const command = normalizeCommand(rawCommand.toLowerCase());
-			const label = labelParts.join(" ").trim() || undefined;
-
-			if (!command) {
-				ctx.ui.notify(`Unknown attention command: ${rawCommand}`, "warning");
-				return;
-			}
-
-			if (command === "status") {
-				const pane = readPaneId();
-				if (!pane.ok) {
-					ctx.ui.notify(
-						pane.reason === "missing-pane"
-							? "WEZTERM_PANE is not set; attention markers are disabled"
-							: "WEZTERM_PANE is not a valid pane id; attention markers are disabled",
-						"info",
-					);
-					return;
-				}
-				const marker = await readMarkerText();
-				ctx.ui.notify(marker ? `WezTerm attention marker: ${marker}` : "No WezTerm attention marker for this pane", "info");
-				return;
-			}
-
-			if (command === "clear") {
-				const { text, level } = clearMessage(await clearMarker());
-				ctx.ui.notify(text, level);
-				return;
-			}
-
-			const { text, level } = writeMessage(await mark(command, label), command);
-			ctx.ui.notify(text, level);
-		},
+	// Cooperative: any other Pi extension (e.g. an ask-user extension) can emit
+	// this event to request a state — notably `notify` (the "waiting for you" `!`),
+	// which the lifecycle events never produce. Emit a bare string ("notify") or
+	// an object ({ type: "notify", label }); "clear" removes the marker.
+	pi.events.on(ATTENTION_EVENT, (data) => {
+		const request = normalizeEventData(data);
+		if (!request) return;
+		if (request.state === "clear") {
+			void clearMarker();
+			return;
+		}
+		void mark(request.state, request.label);
 	});
 }

--- a/pi/index.ts
+++ b/pi/index.ts
@@ -1,10 +1,13 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { mkdir, rename, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 
 const DEFAULT_TTL_MS = 30 * 60 * 1000;
 const ATTENTION_EVENT = "wezterm-attention:mark";
+// Cap the session_shutdown drain so a hung marker FS can never wedge Pi's reload
+// or quit. Normal writes settle in single-digit ms; this is only a safety valve.
+const DRAIN_TIMEOUT_MS = 2000;
 
 type AttentionState = "thinking" | "stop" | "notify" | "review";
 
@@ -16,8 +19,16 @@ type Marker = {
 	ttl_ms?: number;
 };
 
-function markerDirectory(): string {
-	return process.env.WEZTERM_ATTENTION_DIR ?? join(process.env.HOME ?? homedir(), ".local", "state", "wezterm-attention");
+// Resolve the marker directory, then require it to be absolute. This closes two
+// degenerate-env holes: WEZTERM_ATTENTION_DIR="" would otherwise leave the clear
+// path calling rm() on a cwd-relative name (deleting a file where Pi was
+// launched), and HOME="" resolves to a relative ".local/..." that scatters
+// markers into the launch directory where the plugin never looks. `||` (not
+// `??`) folds an empty override or empty HOME into the fallback; the isAbsolute
+// gate rejects any still-relative result so the caller no-ops.
+function markerDirectory(): string | undefined {
+	const dir = process.env.WEZTERM_ATTENTION_DIR || join(process.env.HOME || homedir(), ".local", "state", "wezterm-attention");
+	return isAbsolute(dir) ? dir : undefined;
 }
 
 // WezTerm injects WEZTERM_PANE as a non-negative integer pane id. Validate the
@@ -32,7 +43,11 @@ function paneId(): string | undefined {
 function ttlMs(): number {
 	const raw = process.env.PI_WEZTERM_ATTENTION_TTL_MS;
 	if (!raw) return DEFAULT_TTL_MS;
-	const parsed = Number.parseInt(raw, 10);
+	// Strict digits only: parseInt("30m") is 30, silently turning a "30 minutes"
+	// typo into a 30ms TTL that expires the spinner almost instantly. Reject
+	// anything that isn't a plain integer and fall back to the default.
+	if (!/^\d+$/.test(raw.trim())) return DEFAULT_TTL_MS;
+	const parsed = Number.parseInt(raw.trim(), 10);
 	return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_TTL_MS;
 }
 
@@ -62,8 +77,10 @@ function normalizeState(value: string): AttentionState | "clear" | undefined {
 // All mutations run through one serial chain so emit order == apply order even
 // for the fire-and-forget event path: a `notify` immediately followed by a
 // `clear` must not race (rm finishing before the write's rename would leave the
-// marker present). The chain swallows results so one failure never poisons later
-// operations.
+// marker present). The chain is module-local; cross-generation ordering across a
+// reload is handled by draining it in session_shutdown (which Pi awaits before
+// re-evaluating the module), not by any per-generation disposal here. The chain
+// swallows results so one failure never poisons later operations.
 let mutationChain: Promise<unknown> = Promise.resolve();
 function enqueue(op: () => Promise<void>): Promise<void> {
 	const run = mutationChain.then(op, op);
@@ -84,6 +101,7 @@ async function writeMarkerNow(state: AttentionState, label?: string): Promise<vo
 	if (!id) return;
 
 	const dir = markerDirectory();
+	if (!dir) return;
 	const path = join(dir, id);
 	const marker: Marker = {
 		type: state,
@@ -110,8 +128,10 @@ async function writeMarkerNow(state: AttentionState, label?: string): Promise<vo
 async function clearMarkerNow(): Promise<void> {
 	const id = paneId();
 	if (!id) return;
+	const dir = markerDirectory();
+	if (!dir) return;
 	try {
-		await rm(join(markerDirectory(), id), { force: true });
+		await rm(join(dir, id), { force: true });
 	} catch {
 		// Best-effort.
 	}
@@ -151,8 +171,38 @@ function normalizeEventData(data: unknown): { state: AttentionState | "clear"; l
 	return { state, ...(label ? { label } : {}) };
 }
 
+// Retire the previous generation's bus listener when a NEW generation registers,
+// rather than in session_shutdown. The shared event bus is not cleared on reload,
+// so a leaked listener would accumulate — but disposal cannot happen on shutdown:
+// reload() emits session_shutdown BEFORE its fallible work, and handleReloadCommand
+// catches a reload failure and keeps the session running, so disposing on shutdown
+// would kill the notify path with no replacement. Disposing only once a successor
+// provably exists (at the next registration) avoids that. The registry is a
+// WeakMap keyed by the bus object, so a multi-loader process never disposes
+// another bus's listener.
+//
+// This keying relies on `pi.events` being referentially stable across /reload.
+// The bus is created once per resource-loader (not strictly per process) and the
+// same object is passed to every reloaded generation, which holds. A /new, /fork,
+// /resume, or fresh import gets a DIFFERENT bus — that is safe, not a leak:
+// nothing emits on or retains the old bus, and the WeakMap value closes over the
+// emitter rather than the key, so the stale entry is collectible. Only a
+// hypothetical Pi that swapped the bus on /reload itself would defeat the keying.
+const REGISTRY_KEY = "__weztermAttentionPiBusRegistry__";
+function busRegistry(): WeakMap<object, () => void> {
+	const g = globalThis as Record<string, unknown>;
+	let reg = g[REGISTRY_KEY] as WeakMap<object, () => void> | undefined;
+	if (!reg) {
+		reg = new WeakMap();
+		g[REGISTRY_KEY] = reg;
+	}
+	return reg;
+}
+
 export default function weztermAttentionPiExtension(pi: ExtensionAPI): void {
-	// Automatic: Pi lifecycle → WezTerm tab state. These produce thinking/stop only.
+	// Automatic: Pi lifecycle → WezTerm tab state. Lifecycle handlers are stored
+	// per-extension-instance by Pi's runner and replaced wholesale on reload, so
+	// they don't accumulate — safe to register on every load.
 	pi.on("agent_start", async () => {
 		await mark("thinking");
 	});
@@ -161,7 +211,12 @@ export default function weztermAttentionPiExtension(pi: ExtensionAPI): void {
 		await mark("thinking");
 	});
 
-	pi.on("agent_end", async () => {
+	// `agent_settled`, NOT `agent_end`: agent_end fires at the end of every
+	// low-level run, but Pi may still auto-retry, auto-compact and retry, or
+	// continue with queued follow-up messages — writing `stop` there flashes a
+	// false ✓ mid-task. agent_settled fires only once Pi will not continue
+	// running automatically. Requires Pi >= 0.80.5.
+	pi.on("agent_settled", async () => {
 		await mark("stop");
 	});
 
@@ -171,9 +226,46 @@ export default function weztermAttentionPiExtension(pi: ExtensionAPI): void {
 	// an object ({ type: "notify", label }); "clear" removes the marker.
 	// The bus ignores the handler's return value; we return the mutation promise
 	// so callers/tests can await completion deterministically.
-	pi.events.on(ATTENTION_EVENT, (data) => {
+	//
+	// Register ours FIRST, record it, THEN retire the prior generation's listener
+	// on THIS bus (see busRegistry) so reloads never accumulate listeners. This is
+	// synchronous — no await between the steps — so no emit can observe both live.
+	// Ordering it register-then-retire means a throw in `pi.events.on` can never
+	// leave zero listeners (the old one survives); the worst case is a leak, never
+	// silence.
+	const registry = busRegistry();
+	const bus = pi.events as unknown as object;
+	const prev = registry.get(bus);
+	const disposeEvent = pi.events.on(ATTENTION_EVENT, (data) => {
 		const request = normalizeEventData(data);
 		if (!request) return;
 		return request.state === "clear" ? clearMarker() : mark(request.state, request.label);
+	});
+	registry.set(bus, disposeEvent);
+	prev?.();
+
+	// Drain in-flight writes on teardown. Pi awaits session_shutdown before it
+	// re-loads extensions, so every write ENQUEUED BEFORE shutdown settles before
+	// the next generation's (fresh) chain starts — the common-path cross-reload
+	// ordering case. (One narrow, self-correcting residual: our listener is kept
+	// live through the reload for failed-reload safety, so a late emit delivered
+	// during Pi's post-shutdown steps enqueues on the old chain and could still be
+	// writing as the new generation writes; the next event corrects the marker.)
+	// We deliberately do NOT dispose here (that happens at the next registration);
+	// disposing on a shutdown that precedes a *failed* reload would silence us
+	// with no successor.
+	//
+	// The drain is bounded: Pi awaits this handler with no timeout of its own, so
+	// a hung marker FS must never wedge /reload or quit. Markers are best-effort;
+	// capping the wait matches that contract.
+	pi.on("session_shutdown", async () => {
+		let timer: ReturnType<typeof setTimeout> | undefined;
+		await Promise.race([
+			mutationChain,
+			new Promise<void>((resolve) => {
+				timer = setTimeout(resolve, DRAIN_TIMEOUT_MS);
+			}),
+		]);
+		if (timer) clearTimeout(timer);
 	});
 }

--- a/pi/index.ts
+++ b/pi/index.ts
@@ -1,15 +1,14 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { randomUUID } from "node:crypto";
 import { mkdir, rename, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { isAbsolute, join } from "node:path";
 
 const DEFAULT_TTL_MS = 30 * 60 * 1000;
 const ATTENTION_EVENT = "wezterm-attention:mark";
-// Cap the session_shutdown drain so a hung marker FS can never wedge Pi's reload
-// or quit. Measured p99 for one write is well under a millisecond, so this is
-// only a safety valve — but note it bounds the WHOLE queued backlog, not a single
-// write: the drain awaits the tail of the serial chain, so N queued writes trip
-// it once their SUM exceeds the cap, even though no individual write is slow.
+// Cap for the session_shutdown drain. Bounds the WHOLE queued backlog, not one
+// write — the drain awaits the tail of the serial chain, so N writes trip it once
+// their SUM exceeds the cap, even though no single write is slow.
 const DRAIN_TIMEOUT_MS = 2000;
 
 type AttentionState = "thinking" | "stop" | "notify" | "review";
@@ -85,10 +84,10 @@ function normalizeState(value: string): AttentionState | "clear" | undefined {
 // All mutations run through one serial chain so emit order == apply order even
 // for the fire-and-forget event path: a `notify` immediately followed by a
 // `clear` must not race (rm finishing before the write's rename would leave the
-// marker present). The chain is module-local; cross-generation ordering across a
-// reload is handled by draining it in session_shutdown (which Pi awaits before
-// re-evaluating the module), not by any per-generation disposal here. The chain
-// swallows results so one failure never poisons later operations.
+// marker present). The chain is module-local; cross-reload ordering comes from
+// the session_shutdown drain. Results are swallowed so one failure never poisons
+// later operations — that contract is `enqueue`'s own, deliberately independent
+// of whether today's callers happen to be non-rejecting.
 let mutationChain: Promise<unknown> = Promise.resolve();
 function enqueue(op: () => Promise<void>): Promise<void> {
 	const run = mutationChain.then(op, op);
@@ -98,11 +97,6 @@ function enqueue(op: () => Promise<void>): Promise<void> {
 	);
 	return run;
 }
-
-// Monotonic counter keeps temp filenames unique within the process even for
-// same-millisecond writes; serialization already prevents overlap, this is
-// defense in depth.
-let tmpSeq = 0;
 
 async function writeMarkerNow(state: AttentionState, label?: string): Promise<void> {
 	const id = paneId();
@@ -119,7 +113,7 @@ async function writeMarkerNow(state: AttentionState, label?: string): Promise<vo
 	if (label) marker.label = label;
 	if (state === "thinking") marker.ttl_ms = ttlMs();
 
-	const tmp = `${path}.tmp.${process.pid}.${Date.now()}.${tmpSeq++}`;
+	const tmp = `${path}.tmp.${randomUUID()}`;
 	try {
 		await mkdir(dir, { recursive: true });
 		await writeFile(tmp, JSON.stringify(marker) + "\n");
@@ -127,8 +121,7 @@ async function writeMarkerNow(state: AttentionState, label?: string): Promise<vo
 	} catch {
 		// Best-effort: a marker that fails to write just means the tab doesn't change.
 		// A failed rename (e.g. the destination is a directory) leaves tmp behind —
-		// remove it so failures don't accumulate filesystem residue. Cleanup only on
-		// failure; on success tmp was already renamed away.
+		// remove it so failures don't accumulate filesystem residue.
 		await rm(tmp, { force: true }).catch(() => {});
 	}
 }
@@ -161,7 +154,7 @@ function stringFromUnknown(value: unknown): string | undefined {
 	return typeof value === "string" ? value : undefined;
 }
 
-// Accepts a bare string ("notify") or an object ({ type | state | command, label }).
+// Accepts a bare string ("notify") or an object ({ type | state, label }).
 function normalizeEventData(data: unknown): { state: AttentionState | "clear"; label?: string } | undefined {
 	if (typeof data === "string") {
 		const state = normalizeState(data);
@@ -169,7 +162,7 @@ function normalizeEventData(data: unknown): { state: AttentionState | "clear"; l
 	}
 	if (!isRecord(data)) return undefined;
 
-	const raw = stringFromUnknown(data.state) ?? stringFromUnknown(data.type) ?? stringFromUnknown(data.command);
+	const raw = stringFromUnknown(data.type) ?? stringFromUnknown(data.state);
 	if (!raw) return undefined;
 
 	const state = normalizeState(raw);
@@ -189,13 +182,10 @@ function normalizeEventData(data: unknown): { state: AttentionState | "clear"; l
 // WeakMap keyed by the bus object, so a multi-loader process never disposes
 // another bus's listener.
 //
-// This keying relies on `pi.events` being referentially stable across /reload.
-// The bus is created once per resource-loader (not strictly per process) and the
-// same object is passed to every reloaded generation, which holds. A /new, /fork,
-// /resume, or fresh import gets a DIFFERENT bus — that is safe, not a leak:
-// nothing emits on or retains the old bus, and the WeakMap value closes over the
-// emitter rather than the key, so the stale entry is collectible. Only a
-// hypothetical Pi that swapped the bus on /reload itself would defeat the keying.
+// Keyed on `pi.events`, which is referentially stable across /reload (one bus per
+// resource-loader, handed to every reloaded generation). A /new, /fork, /resume or
+// fresh import gets a different bus; that is correct, not a leak — nothing retains
+// the old one, so its WeakMap entry is collectible.
 const REGISTRY_KEY = "__weztermAttentionPiBusRegistry__";
 function busRegistry(): WeakMap<object, () => void> {
 	const g = globalThis as Record<string, unknown>;
@@ -205,6 +195,26 @@ function busRegistry(): WeakMap<object, () => void> {
 		g[REGISTRY_KEY] = reg;
 	}
 	return reg;
+}
+
+// Register this generation's listener, then retire the predecessor's. Order is
+// load-bearing: register-before-retire means a throw in `pi.events.on` leaks a
+// listener rather than leaving zero, and the steps are synchronous so no emit can
+// observe both live. Retiring is best-effort — a throwing disposer must never fail
+// the host's reload.
+//
+// This function is the seam the bus-owned-controller design would replace.
+function installBusListener(pi: ExtensionAPI, handler: (data: unknown) => unknown): void {
+	const registry = busRegistry();
+	const bus = pi.events as unknown as object;
+	const prev = registry.get(bus);
+	const disposeEvent = pi.events.on(ATTENTION_EVENT, handler);
+	registry.set(bus, disposeEvent);
+	try {
+		prev?.();
+	} catch {
+		// Best-effort dedup; a failed retire leaves a duplicate, never a broken load.
+	}
 }
 
 export default function weztermAttentionPiExtension(pi: ExtensionAPI): void {
@@ -234,52 +244,23 @@ export default function weztermAttentionPiExtension(pi: ExtensionAPI): void {
 	// an object ({ type: "notify", label }); "clear" removes the marker.
 	// The bus ignores the handler's return value; we return the mutation promise
 	// so callers/tests can await completion deterministically.
-	//
-	// Register ours FIRST, record it, THEN retire the prior generation's listener
-	// on THIS bus (see busRegistry) so reloads never accumulate listeners. This is
-	// synchronous — no await between the steps — so no emit can observe both live.
-	// Ordering it register-then-retire means a throw in `pi.events.on` can never
-	// leave zero listeners (the old one survives); the worst case is a leak, never
-	// silence.
-	const registry = busRegistry();
-	const bus = pi.events as unknown as object;
-	const prev = registry.get(bus);
-	const disposeEvent = pi.events.on(ATTENTION_EVENT, (data) => {
+	installBusListener(pi, (data) => {
 		const request = normalizeEventData(data);
 		if (!request) return;
 		return request.state === "clear" ? clearMarker() : mark(request.state, request.label);
 	});
-	registry.set(bus, disposeEvent);
-	prev?.();
 
-	// Drain in-flight writes on teardown. Pi awaits session_shutdown before it
-	// re-loads extensions, so every write ENQUEUED BEFORE shutdown settles before
-	// the next generation's (fresh) chain starts — the common-path cross-reload
-	// ordering case. (One narrow, self-correcting residual: our listener is kept
-	// live through the reload for failed-reload safety, so a late emit delivered
-	// during Pi's post-shutdown steps enqueues on the old chain and could still be
-	// writing as the new generation writes; the next event corrects the marker.)
-	// We deliberately do NOT dispose here (that happens at the next registration);
-	// disposing on a shutdown that precedes a *failed* reload would silence us
-	// with no successor.
+	// Drain in-flight writes on teardown: Pi awaits session_shutdown before it
+	// re-loads, so everything enqueued before shutdown lands before the next
+	// generation's fresh chain starts. Drain only — do NOT dispose the listener
+	// here (see installBusListener): a shutdown preceding a *failed* reload would
+	// leave us silenced with no successor.
 	//
-	// The drain is bounded: Pi awaits this handler with no timeout of its own, so
-	// a hung marker FS must never wedge /reload or quit.
-	//
-	// Be precise about what the cap trades away. Timing out does NOT cancel the
-	// abandoned write — it is still in flight, and it can land AFTER the next
-	// generation has written, leaving the older state on disk (e.g. a stale
-	// `thinking` overwriting a fresh `stop`, which the plugin then renders until
-	// the next event or the marker's own ttl_ms expires). So the cap converts
-	// "reload hangs" into "marker may be briefly wrong", which is the right trade
-	// for a best-effort indicator, but it is a different failure, not no failure.
-	// Reachable only on /reload and the /new,/fork,/resume teardowns (quit exits
-	// the process immediately), and only when the queued backlog exceeds the cap.
-	//
-	// Do NOT "fix" this with a sticky abandoned flag that suppresses later writes:
-	// a generation survives a *failed* reload by design (see above and the
-	// failed-reload test), so one timeout plus one failed reload would silence the
-	// extension permanently. Gate on a per-operation generation counter instead.
+	// The cap does not cancel an abandoned write; it can land after the next
+	// generation's write and leave stale state until the next event or the marker's
+	// ttl_ms. Accepted trade for a best-effort indicator. Do not "fix" it with a
+	// sticky abandoned flag — one failed reload turns that into permanent silence;
+	// use a per-operation generation counter if it ever matters.
 	pi.on("session_shutdown", async () => {
 		let timer: ReturnType<typeof setTimeout> | undefined;
 		await Promise.race([

--- a/pi/index.ts
+++ b/pi/index.ts
@@ -1,0 +1,207 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const DEFAULT_TTL_MS = 30 * 60 * 1000;
+const ATTENTION_EVENT = "wezterm-attention:mark";
+
+type AttentionState = "thinking" | "stop" | "notify" | "review";
+type AttentionCommand = "busy" | "thinking" | "ready" | "stop" | "blocked" | "pending" | "notify" | "review" | "clear" | "status";
+
+type Marker = {
+	type: AttentionState;
+	source: "pi";
+	updated_at: number;
+	label?: string;
+	ttl_ms?: number;
+};
+
+const COMMANDS: Array<{ value: AttentionCommand; description: string }> = [
+	{ value: "busy", description: "Mark this pane as thinking" },
+	{ value: "ready", description: "Mark this pane as done" },
+	{ value: "pending", description: "Alias for notify; mark this pane as waiting for human input" },
+	{ value: "blocked", description: "Alias for notify" },
+	{ value: "review", description: "Mark this pane for manual review" },
+	{ value: "clear", description: "Clear this pane's attention marker" },
+	{ value: "status", description: "Show current marker state" },
+];
+
+function markerDirectory(): string {
+	return process.env.WEZTERM_ATTENTION_DIR ?? join(process.env.HOME ?? homedir(), ".local", "state", "wezterm-attention");
+}
+
+function markerPath(): string | undefined {
+	const paneId = process.env.WEZTERM_PANE;
+	if (!paneId) return undefined;
+	return join(markerDirectory(), paneId);
+}
+
+function ttlMs(): number {
+	const raw = process.env.PI_WEZTERM_ATTENTION_TTL_MS;
+	if (!raw) return DEFAULT_TTL_MS;
+	const parsed = Number.parseInt(raw, 10);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_TTL_MS;
+}
+
+function normalizeCommand(command: string): AttentionState | "clear" | "status" | undefined {
+	switch (command) {
+		case "busy":
+		case "thinking":
+			return "thinking";
+		case "ready":
+		case "stop":
+			return "stop";
+		case "blocked":
+		case "pending":
+		case "notify":
+			return "notify";
+		case "review":
+			return "review";
+		case "clear":
+			return "clear";
+		case "status":
+		case "":
+			return "status";
+		default:
+			return undefined;
+	}
+}
+
+async function writeMarker(state: AttentionState, label?: string): Promise<boolean> {
+	const path = markerPath();
+	if (!path) return false;
+
+	const marker: Marker = {
+		type: state,
+		source: "pi",
+		updated_at: Date.now(),
+	};
+	if (label) marker.label = label;
+	if (state === "thinking") marker.ttl_ms = ttlMs();
+
+	try {
+		await mkdir(markerDirectory(), { recursive: true });
+		const tmp = `${path}.tmp.${process.pid}.${Date.now()}`;
+		await writeFile(tmp, JSON.stringify(marker) + "\n");
+		await rename(tmp, path);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function clearMarker(): Promise<boolean> {
+	const path = markerPath();
+	if (!path) return false;
+	try {
+		await rm(path, { force: true });
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function readMarkerText(): Promise<string | undefined> {
+	const path = markerPath();
+	if (!path) return undefined;
+	try {
+		return await readFile(path, "utf8");
+	} catch {
+		return undefined;
+	}
+}
+
+async function mark(state: AttentionState, label?: string): Promise<boolean> {
+	return writeMarker(state, label);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringFromUnknown(value: unknown): string | undefined {
+	return typeof value === "string" ? value : undefined;
+}
+
+function normalizeEventData(data: unknown): { state: AttentionState | "clear"; label?: string } | undefined {
+	if (typeof data === "string") {
+		const state = normalizeCommand(data);
+		return state && state !== "status" ? { state } : undefined;
+	}
+	if (!isRecord(data)) return undefined;
+
+	const rawState = stringFromUnknown(data.state) ?? stringFromUnknown(data.type) ?? stringFromUnknown(data.command);
+	if (!rawState) return undefined;
+
+	const state = normalizeCommand(rawState);
+	if (!state || state === "status") return undefined;
+
+	const label = stringFromUnknown(data.label);
+	return { state, ...(label ? { label } : {}) };
+}
+
+export default function weztermAttentionPiExtension(pi: ExtensionAPI): void {
+	pi.events.on(ATTENTION_EVENT, (data) => {
+		const request = normalizeEventData(data);
+		if (!request) return;
+		if (request.state === "clear") {
+			void clearMarker();
+			return;
+		}
+		void mark(request.state, request.label);
+	});
+
+	pi.on("agent_start", async () => {
+		await mark("thinking");
+	});
+
+	pi.on("tool_execution_start", async () => {
+		await mark("thinking");
+	});
+
+	pi.on("agent_end", async () => {
+		await mark("stop");
+	});
+
+	pi.registerCommand("attention", {
+		description: "Control the WezTerm attention marker for this Pi pane",
+		getArgumentCompletions: (prefix) => {
+			const normalizedPrefix = prefix.trim().toLowerCase();
+			return COMMANDS.filter((command) => command.value.startsWith(normalizedPrefix)).map((command) => ({
+				value: command.value,
+				label: command.value,
+				description: command.description,
+			}));
+		},
+		handler: async (args, ctx) => {
+			const [rawCommand = "status", ...labelParts] = args.trim().split(/\s+/).filter(Boolean);
+			const command = normalizeCommand(rawCommand.toLowerCase());
+			const label = labelParts.join(" ").trim() || undefined;
+
+			if (!command) {
+				ctx.ui.notify(`Unknown attention command: ${rawCommand}`, "warning");
+				return;
+			}
+
+			if (command === "status") {
+				const marker = await readMarkerText();
+				if (!marker) {
+					ctx.ui.notify(process.env.WEZTERM_PANE ? "No WezTerm attention marker for this pane" : "WEZTERM_PANE is not set; attention markers are disabled", "info");
+					return;
+				}
+				ctx.ui.notify(`WezTerm attention marker: ${marker}`, "info");
+				return;
+			}
+
+			if (command === "clear") {
+				const cleared = await clearMarker();
+				ctx.ui.notify(cleared ? "Cleared WezTerm attention marker" : "WEZTERM_PANE is not set; nothing to clear", "info");
+				return;
+			}
+
+			const marked = await mark(command, label);
+			ctx.ui.notify(marked ? `Marked WezTerm pane as ${command}` : "WEZTERM_PANE is not set; nothing written", "info");
+		},
+	});
+}

--- a/pi/index.ts
+++ b/pi/index.ts
@@ -21,18 +21,11 @@ type Marker = {
 	ttl_ms?: number;
 };
 
-// Resolve the marker directory, then require it to be absolute. This closes two
-// degenerate-env holes: WEZTERM_ATTENTION_DIR="" would otherwise leave the clear
-// path calling rm() on a cwd-relative name (deleting a file where Pi was
-// launched), and HOME="" resolves to a relative ".local/..." that scatters
-// markers into the launch directory where the plugin never looks.
-//
-// The two operators do NOT split that work evenly. `||` (not `??`) matters only
-// for the override: with `||` an empty WEZTERM_ATTENTION_DIR falls through to the
-// HOME-based default and markers are still written, where `??` would keep "" and
-// no-op everything. For HOME it changes nothing — os.homedir() also returns ""
-// when HOME="" — so the isAbsolute gate below is what actually closes that hole.
-// Do not remove it on the assumption that `||` covers HOME; it does not.
+// Resolve the marker dir and require it absolute — closes two degenerate-env holes:
+// WEZTERM_ATTENTION_DIR="" would make clear's rm() delete a cwd-relative file, and
+// HOME="" resolves to a relative ".local/..." that scatters markers. `||` (not `??`)
+// so an empty override falls through to the HOME default; the isAbsolute gate is what
+// closes the HOME hole (homedir() also returns "" for HOME=""), so don't drop it.
 function markerDirectory(): string | undefined {
 	const dir = process.env.WEZTERM_ATTENTION_DIR || join(process.env.HOME || homedir(), ".local", "state", "wezterm-attention");
 	return isAbsolute(dir) ? dir : undefined;
@@ -172,20 +165,13 @@ function normalizeEventData(data: unknown): { state: AttentionState | "clear"; l
 	return { state, ...(label ? { label } : {}) };
 }
 
-// Retire the previous generation's bus listener when a NEW generation registers,
-// rather than in session_shutdown. The shared event bus is not cleared on reload,
-// so a leaked listener would accumulate — but disposal cannot happen on shutdown:
-// reload() emits session_shutdown BEFORE its fallible work, and handleReloadCommand
-// catches a reload failure and keeps the session running, so disposing on shutdown
-// would kill the notify path with no replacement. Disposing only once a successor
-// provably exists (at the next registration) avoids that. The registry is a
-// WeakMap keyed by the bus object, so a multi-loader process never disposes
-// another bus's listener.
-//
-// Keyed on `pi.events`, which is referentially stable across /reload (one bus per
-// resource-loader, handed to every reloaded generation). A /new, /fork, /resume or
-// fresh import gets a different bus; that is correct, not a leak — nothing retains
-// the old one, so its WeakMap entry is collectible.
+// Retire the previous generation's bus listener at the NEXT registration, not in
+// session_shutdown. The shared bus is never cleared, so listeners would accumulate —
+// but disposing on shutdown is unsafe: reload() emits it before its fallible work, and
+// a caught reload failure keeps the old generation running, so we'd kill the notify
+// path with no replacement. Disposing only once a successor exists avoids that. Keyed
+// on `pi.events`, stable across /reload (one bus per resource-loader); a /new, /fork,
+// /resume or fresh import gets a different bus — safe, its stale entry is collectible.
 const REGISTRY_KEY = "__weztermAttentionPiBusRegistry__";
 function busRegistry(): WeakMap<object, () => void> {
 	const g = globalThis as Record<string, unknown>;
@@ -197,12 +183,9 @@ function busRegistry(): WeakMap<object, () => void> {
 	return reg;
 }
 
-// Register this generation's listener, then retire the predecessor's. Order is
-// load-bearing: register-before-retire means a throw in `pi.events.on` leaks a
-// listener rather than leaving zero, and the steps are synchronous so no emit can
-// observe both live. Retiring is best-effort — a throwing disposer must never fail
-// the host's reload.
-//
+// Register FIRST, then retire the predecessor: a throw in `pi.events.on` then leaks a
+// listener rather than leaving zero, and the steps are synchronous so no emit sees
+// both. Retiring is best-effort — a throwing disposer must not fail the host reload.
 // This function is the seam the bus-owned-controller design would replace.
 function installBusListener(pi: ExtensionAPI, handler: (data: unknown) => unknown): void {
 	const registry = busRegistry();
@@ -218,27 +201,19 @@ function installBusListener(pi: ExtensionAPI, handler: (data: unknown) => unknow
 }
 
 export default function weztermAttentionPiExtension(pi: ExtensionAPI): void {
-	// Automatic: Pi lifecycle → WezTerm tab state. Lifecycle handlers are stored
-	// per-extension-instance by Pi's runner and replaced wholesale on reload, so
-	// they don't accumulate — safe to register on every load.
-	// These do NOT await the write. Pi awaits lifecycle handlers on the agent's own
-	// critical path — agent-loop.ts emits `tool_execution_start` and awaits it before
-	// preparing the tool call, through agent.ts's serial `await listener(...)` and
-	// agent-session.ts's `await this._emitExtensionEvent(event)`, down to runner.ts's
-	// `await handler(event, ctx)`. None of those has a timeout. So awaiting a marker
-	// write here puts the filesystem inside the agent's latency budget, and on a mount
-	// whose syscalls block indefinitely (hard NFS/SMB, dead FUSE daemon) it wedges the
-	// host outright: every write shares one serial chain, so a single stuck op parks
-	// every later lifecycle event too, the TUI never sees the event (the notify at
-	// agent-session.ts:601 is downstream of the await), and aborting does not release
-	// an already-parked await. Headless is worse — `_resolveIdleWaitIfIdle()` sits in a
-	// `finally` whose `try` awaits this emit, so `pi -p` never terminates.
+	// Automatic: Pi lifecycle → WezTerm tab state. Lifecycle handlers are per-instance,
+	// replaced wholesale on reload, so they don't accumulate (unlike the shared bus
+	// listener below — no dedup needed here).
 	//
-	// A tab tint is best-effort; the host's liveness is not ours to spend. Ordering is
-	// unaffected: `enqueue` chains synchronously at call time, so emit order == apply
-	// order is a property of CALL order, not await order. The session_shutdown drain is
-	// what guarantees these land before a reload — which makes that drain load-bearing
-	// in a way it was not before. Do not weaken it.
+	// These do NOT await the write. Pi awaits lifecycle handlers on the agent's own
+	// critical path with no timeout, so awaiting marker I/O here would put the
+	// filesystem in the agent's latency budget — and on a mount whose syscalls block
+	// forever (hard NFS/SMB, dead FUSE) it would wedge the host (one stuck op parks
+	// every later event via the shared chain; headless `pi -p` never terminates). A tab
+	// tint is best-effort; host liveness is not. Ordering is unaffected — `enqueue`
+	// chains synchronously at call time, so emit order == apply order regardless of the
+	// await. The session_shutdown drain now guarantees these land before a reload; don't
+	// weaken it.
 	pi.on("agent_start", () => {
 		void mark("thinking").catch(() => {});
 	});
@@ -268,52 +243,31 @@ export default function weztermAttentionPiExtension(pi: ExtensionAPI): void {
 		return request.state === "clear" ? clearMarker() : mark(request.state, request.label);
 	});
 
-	// Drain in-flight writes on teardown: Pi awaits session_shutdown before it
-	// re-loads, so everything enqueued before shutdown lands before the next
-	// generation's fresh chain starts. Drain only — do NOT dispose the listener
-	// here (see installBusListener): a shutdown preceding a *failed* reload would
-	// leave us silenced with no successor.
+	// Drain in-flight writes on teardown: Pi awaits session_shutdown before re-loading,
+	// so everything enqueued before shutdown lands before the next generation's fresh
+	// chain. Drain only — do NOT dispose the listener here (see installBusListener): a
+	// shutdown before a *failed* reload would leave us with no successor.
 	//
-	// The cap does not cancel an abandoned write; it can land after the next
-	// generation's write and leave stale state. A stale *write* self-limits — the
-	// next event overwrites it, or its ttl_ms expires it. Same residual, same fix,
-	// for an op enqueued AFTER this race snapshots the chain — e.g. a later extension
-	// emitting `clear` on the bus during its own session_shutdown, which our still-live
-	// listener enqueues past the snapshot, so the cap never sees it. Note a late
-	// `clear` REMOVES the successor's marker, and ttl_ms cannot self-heal an absent
-	// file — only a later lifecycle/event write restores it. Accepted trade for a
-	// best-effort indicator.
+	// Two residuals are accepted best-effort costs, with different triggers:
+	//   1. Ordering — on a merely slow or racing write, no dead mount needed: the cap
+	//      doesn't cancel a write that overruns it, nor an op enqueued after this race
+	//      snapshots the chain (e.g. a later extension emitting `clear` on the bus during
+	//      its own shutdown, which our still-live listener enqueues past the snapshot — a
+	//      pure race, fine on a healthy system). A stale write self-limits (next event or
+	//      ttl_ms); a stale `clear` removes the marker, and ttl_ms can't restore an absent
+	//      file — only a later write does.
+	//   2. Memory — only under a *permanently* blocked write (a dead NFS/SMB/FUSE mount,
+	//      not a merely slow one): the chain retains every op queued behind the stuck head
+	//      (a real in-flight fs op is libuv-rooted), growing until the mount recovers or
+	//      the process restarts.
 	//
-	// Second accepted cost under a *permanently* blocked write (dead NFS/SMB/FUSE
-	// mount, not a merely slow one): the serial chain retains every op queued behind
-	// the stuck head, because a real in-flight fs op is rooted by libuv and holds its
-	// forward reaction chain (each op captures its marker + label). Measured ~0.6 KB
-	// per queued op — unbounded until the mount recovers or the process restarts, on
-	// the same rare precondition as the clobber above. NOT worth a coalescing mailbox:
-	// that bounds memory but breaks the FIFO ordering the tests lock, dropping
-	// intermediate states — the bus-owned controller below is the right home if it
-	// ever earns its trigger.
-	//
-	// Three fixes look obvious here and all three are worse than the defect:
-	//
-	// - A sticky abandoned flag: a generation survives a *failed* reload by design,
-	//   so one timeout plus one failed reload is permanent silence.
-	// - Sharing the chain across generations (proposed independently twice, so expect
-	//   it again): lifecycle handlers no longer await the write, so this no longer
-	//   risks host liveness — but one shared FIFO lets a predecessor's slow or hung
-	//   write own the head and stall every successor's marker. Measured ~1.3s behind a
-	//   1.5s write; on a hung mount the successor's marker never lands while the backlog
-	//   grows unbounded (fire-and-forget removed the back-pressure that pinned depth at
-	//   1). The module-local chain isolates generations, so a fresh successor always
-	//   publishes at once past a dead predecessor's abandoned chain.
-	// - A per-operation generation counter: closes the queued-backlog case but NOT a
-	//   single write that stalls inside `rename` past the cap, because the gate
-	//   necessarily precedes the publish. Verified: the successor registers while the
-	//   rename is still in flight, then the rename lands and clobbers.
-	//
-	// Closing the remaining case needs the bus-owned controller — one controller per
-	// bus owning the listener and the mutation state, re-asserting the last requested
-	// state after an abandoned write lands. Deferred; its trigger has not arrived.
+	// The obvious fixes are all worse: a sticky abandoned flag → permanent silence after
+	// a failed reload; sharing the chain across generations → a stuck predecessor stalls
+	// or wedges the successor; a per-op generation counter → the gate precedes the
+	// publish, so it can't catch a write already stalling inside rename; a coalescing
+	// mailbox → bounds memory but breaks the FIFO ordering the tests lock. The real fix
+	// is the deferred bus-owned controller (one per bus, owning the listener + mutation
+	// state, re-asserting the last requested state after an abandoned write lands).
 	pi.on("session_shutdown", async () => {
 		let timer: ReturnType<typeof setTimeout> | undefined;
 		await Promise.race([

--- a/pi/index.ts
+++ b/pi/index.ts
@@ -9,6 +9,11 @@ const ATTENTION_EVENT = "wezterm-attention:mark";
 type AttentionState = "thinking" | "stop" | "notify" | "review";
 type AttentionCommand = "busy" | "thinking" | "ready" | "stop" | "blocked" | "pending" | "notify" | "review" | "clear" | "status";
 
+// Outcome of a marker mutation. Distinguishes "no pane" from "bad pane" from an
+// actual filesystem failure so callers can report the true reason rather than
+// collapsing every failure into "WEZTERM_PANE is not set".
+type MarkOutcome = "ok" | "missing-pane" | "invalid-pane" | "io-error";
+
 type Marker = {
 	type: AttentionState;
 	source: "pi";
@@ -31,10 +36,15 @@ function markerDirectory(): string {
 	return process.env.WEZTERM_ATTENTION_DIR ?? join(process.env.HOME ?? homedir(), ".local", "state", "wezterm-attention");
 }
 
-function markerPath(): string | undefined {
-	const paneId = process.env.WEZTERM_PANE;
-	if (!paneId) return undefined;
-	return join(markerDirectory(), paneId);
+// WezTerm injects WEZTERM_PANE as a non-negative integer pane id. Validate the
+// contract before building a path: an unvalidated value like "../../foo" would
+// escape the marker directory, and clearMarker's rm would then delete an
+// arbitrary file. Reject anything that is not purely digits.
+function readPaneId(): { ok: true; id: string } | { ok: false; reason: "missing-pane" | "invalid-pane" } {
+	const id = process.env.WEZTERM_PANE;
+	if (!id) return { ok: false, reason: "missing-pane" };
+	if (!/^\d+$/.test(id)) return { ok: false, reason: "invalid-pane" };
+	return { ok: true, id };
 }
 
 function ttlMs(): number {
@@ -68,10 +78,32 @@ function normalizeCommand(command: string): AttentionState | "clear" | "status" 
 	}
 }
 
-async function writeMarker(state: AttentionState, label?: string): Promise<boolean> {
-	const path = markerPath();
-	if (!path) return false;
+// All marker mutations (and status reads) run through this single serial chain,
+// so emit order equals apply order even for the fire-and-forget event-bus path.
+// Without it, a `notify` immediately followed by `clear` races: rm finishes
+// before the write's rename, leaving the marker present. The chain swallows
+// results so one failure never poisons later operations.
+let mutationChain: Promise<unknown> = Promise.resolve();
+function enqueue<T>(op: () => Promise<T>): Promise<T> {
+	const run = mutationChain.then(op, op);
+	mutationChain = run.then(
+		() => undefined,
+		() => undefined,
+	);
+	return run;
+}
 
+// Monotonic counter makes temp filenames unique within the process even for
+// same-millisecond writes; serialization already prevents overlap, this is
+// defense in depth.
+let tmpSeq = 0;
+
+async function writeMarkerNow(state: AttentionState, label?: string): Promise<MarkOutcome> {
+	const pane = readPaneId();
+	if (!pane.ok) return pane.reason;
+
+	const dir = markerDirectory();
+	const path = join(dir, pane.id);
 	const marker: Marker = {
 		type: state,
 		source: "pi",
@@ -81,39 +113,77 @@ async function writeMarker(state: AttentionState, label?: string): Promise<boole
 	if (state === "thinking") marker.ttl_ms = ttlMs();
 
 	try {
-		await mkdir(markerDirectory(), { recursive: true });
-		const tmp = `${path}.tmp.${process.pid}.${Date.now()}`;
+		await mkdir(dir, { recursive: true });
+		const tmp = `${path}.tmp.${process.pid}.${Date.now()}.${tmpSeq++}`;
 		await writeFile(tmp, JSON.stringify(marker) + "\n");
 		await rename(tmp, path);
-		return true;
+		return "ok";
 	} catch {
-		return false;
+		return "io-error";
 	}
 }
 
-async function clearMarker(): Promise<boolean> {
-	const path = markerPath();
-	if (!path) return false;
+async function clearMarkerNow(): Promise<MarkOutcome> {
+	const pane = readPaneId();
+	if (!pane.ok) return pane.reason;
 	try {
-		await rm(path, { force: true });
-		return true;
+		await rm(join(markerDirectory(), pane.id), { force: true });
+		return "ok";
 	} catch {
-		return false;
+		return "io-error";
 	}
 }
 
+function writeMarker(state: AttentionState, label?: string): Promise<MarkOutcome> {
+	return enqueue(() => writeMarkerNow(state, label));
+}
+
+function clearMarker(): Promise<MarkOutcome> {
+	return enqueue(() => clearMarkerNow());
+}
+
+// Read behind the mutation chain so `status` reflects the latest queued write or
+// clear rather than a stale on-disk state.
 async function readMarkerText(): Promise<string | undefined> {
-	const path = markerPath();
-	if (!path) return undefined;
-	try {
-		return await readFile(path, "utf8");
-	} catch {
-		return undefined;
+	const pane = readPaneId();
+	if (!pane.ok) return undefined;
+	return enqueue(async () => {
+		try {
+			return await readFile(join(markerDirectory(), pane.id), "utf8");
+		} catch {
+			return undefined;
+		}
+	});
+}
+
+async function mark(state: AttentionState, label?: string): Promise<MarkOutcome> {
+	return writeMarker(state, label);
+}
+
+function writeMessage(outcome: MarkOutcome, command: string): { text: string; level: "info" | "warning" } {
+	switch (outcome) {
+		case "ok":
+			return { text: `Marked WezTerm pane as ${command}`, level: "info" };
+		case "missing-pane":
+			return { text: "WEZTERM_PANE is not set; nothing written", level: "info" };
+		case "invalid-pane":
+			return { text: "WEZTERM_PANE is not a valid pane id; nothing written", level: "warning" };
+		case "io-error":
+			return { text: "Failed to write WezTerm marker (I/O error)", level: "warning" };
 	}
 }
 
-async function mark(state: AttentionState, label?: string): Promise<boolean> {
-	return writeMarker(state, label);
+function clearMessage(outcome: MarkOutcome): { text: string; level: "info" | "warning" } {
+	switch (outcome) {
+		case "ok":
+			return { text: "Cleared WezTerm attention marker", level: "info" };
+		case "missing-pane":
+			return { text: "WEZTERM_PANE is not set; nothing to clear", level: "info" };
+		case "invalid-pane":
+			return { text: "WEZTERM_PANE is not a valid pane id; nothing to clear", level: "warning" };
+		case "io-error":
+			return { text: "Failed to clear WezTerm marker (I/O error)", level: "warning" };
+	}
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -185,23 +255,29 @@ export default function weztermAttentionPiExtension(pi: ExtensionAPI): void {
 			}
 
 			if (command === "status") {
-				const marker = await readMarkerText();
-				if (!marker) {
-					ctx.ui.notify(process.env.WEZTERM_PANE ? "No WezTerm attention marker for this pane" : "WEZTERM_PANE is not set; attention markers are disabled", "info");
+				const pane = readPaneId();
+				if (!pane.ok) {
+					ctx.ui.notify(
+						pane.reason === "missing-pane"
+							? "WEZTERM_PANE is not set; attention markers are disabled"
+							: "WEZTERM_PANE is not a valid pane id; attention markers are disabled",
+						"info",
+					);
 					return;
 				}
-				ctx.ui.notify(`WezTerm attention marker: ${marker}`, "info");
+				const marker = await readMarkerText();
+				ctx.ui.notify(marker ? `WezTerm attention marker: ${marker}` : "No WezTerm attention marker for this pane", "info");
 				return;
 			}
 
 			if (command === "clear") {
-				const cleared = await clearMarker();
-				ctx.ui.notify(cleared ? "Cleared WezTerm attention marker" : "WEZTERM_PANE is not set; nothing to clear", "info");
+				const { text, level } = clearMessage(await clearMarker());
+				ctx.ui.notify(text, level);
 				return;
 			}
 
-			const marked = await mark(command, label);
-			ctx.ui.notify(marked ? `Marked WezTerm pane as ${command}` : "WEZTERM_PANE is not set; nothing written", "info");
+			const { text, level } = writeMessage(await mark(command, label), command);
+			ctx.ui.notify(text, level);
 		},
 	});
 }

--- a/pi/index.ts
+++ b/pi/index.ts
@@ -283,11 +283,13 @@ export default function weztermAttentionPiExtension(pi: ExtensionAPI): void {
 	// - A sticky abandoned flag: a generation survives a *failed* reload by design,
 	//   so one timeout plus one failed reload is permanent silence.
 	// - Sharing the chain across generations (proposed independently twice, so expect
-	//   it again): the host awaits lifecycle handlers all the way from the agent loop,
-	//   so a successor inheriting a stuck predecessor's backlog stalls the agent's own
-	//   run — measured as a block equal to the whole abandoned backlog, and on a
-	//   stalled mount a permanent wedge with no marker ever written again. The cap is
-	//   not an oversight to delete; it is what keeps a stuck fs op away from the host.
+	//   it again): lifecycle handlers no longer await the write, so this no longer
+	//   risks host liveness — but one shared FIFO lets a predecessor's slow or hung
+	//   write own the head and stall every successor's marker. Measured ~1.3s behind a
+	//   1.5s write; on a hung mount the successor's marker never lands while the backlog
+	//   grows unbounded (fire-and-forget removed the back-pressure that pinned depth at
+	//   1). The module-local chain isolates generations, so a fresh successor always
+	//   publishes at once past a dead predecessor's abandoned chain.
 	// - A per-operation generation counter: closes the queued-backlog case but NOT a
 	//   single write that stalls inside `rename` past the cap, because the gate
 	//   necessarily precedes the publish. Verified: the successor registers while the

--- a/pi/index.ts
+++ b/pi/index.ts
@@ -93,13 +93,17 @@ async function writeMarkerNow(state: AttentionState, label?: string): Promise<vo
 	if (label) marker.label = label;
 	if (state === "thinking") marker.ttl_ms = ttlMs();
 
+	const tmp = `${path}.tmp.${process.pid}.${Date.now()}.${tmpSeq++}`;
 	try {
 		await mkdir(dir, { recursive: true });
-		const tmp = `${path}.tmp.${process.pid}.${Date.now()}.${tmpSeq++}`;
 		await writeFile(tmp, JSON.stringify(marker) + "\n");
 		await rename(tmp, path);
 	} catch {
 		// Best-effort: a marker that fails to write just means the tab doesn't change.
+		// A failed rename (e.g. the destination is a directory) leaves tmp behind —
+		// remove it so failures don't accumulate filesystem residue. Cleanup only on
+		// failure; on success tmp was already renamed away.
+		await rm(tmp, { force: true }).catch(() => {});
 	}
 }
 
@@ -165,13 +169,11 @@ export default function weztermAttentionPiExtension(pi: ExtensionAPI): void {
 	// this event to request a state — notably `notify` (the "waiting for you" `!`),
 	// which the lifecycle events never produce. Emit a bare string ("notify") or
 	// an object ({ type: "notify", label }); "clear" removes the marker.
+	// The bus ignores the handler's return value; we return the mutation promise
+	// so callers/tests can await completion deterministically.
 	pi.events.on(ATTENTION_EVENT, (data) => {
 		const request = normalizeEventData(data);
 		if (!request) return;
-		if (request.state === "clear") {
-			void clearMarker();
-			return;
-		}
-		void mark(request.state, request.label);
+		return request.state === "clear" ? clearMarker() : mark(request.state, request.label);
 	});
 }

--- a/tests/pi_extension.test.ts
+++ b/tests/pi_extension.test.ts
@@ -1,18 +1,19 @@
 // Regression tests for pi/index.ts, driving the REAL registered lifecycle and
 // event handlers through a mock ExtensionAPI. Named after the properties they
 // lock — several are the negation of a bug fixed during review triage.
-// Run: `bun test`.
+// Mutations are awaited deterministically (the event handler returns its queue
+// promise), never slept on. Run: `bun test`.
 import { test, expect } from "bun:test";
-import { mkdtempSync, mkdirSync, existsSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, existsSync, readFileSync, readdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import ext from "../pi/index.ts";
 
 function loadExt() {
 	const lifecycle: Record<string, () => Promise<void> | void> = {};
-	let eventHandler: (data: unknown) => void = () => {};
+	let eventHandler: (data: unknown) => void | Promise<void> = () => {};
 	const pi = {
-		events: { on: (_e: string, h: (d: unknown) => void) => { eventHandler = h; } },
+		events: { on: (_e: string, h: (d: unknown) => void | Promise<void>) => { eventHandler = h; } },
 		on: (event: string, h: () => Promise<void> | void) => { lifecycle[event] = h; },
 		registerCommand: () => {},
 	};
@@ -20,7 +21,6 @@ function loadExt() {
 	ext(pi as any);
 	return { lifecycle, eventHandler };
 }
-const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 function freshDir(prefix: string): string {
 	const d = mkdtempSync(join(tmpdir(), prefix));
@@ -55,8 +55,7 @@ test("event: emitting a notify object writes a labeled notify marker", async () 
 	const dir = freshDir("wez-evt-");
 	process.env.WEZTERM_PANE = "42";
 	const { eventHandler } = loadExt();
-	eventHandler({ type: "notify", label: "answer me" });
-	await sleep(20);
+	await eventHandler({ type: "notify", label: "answer me" });
 	const m = JSON.parse(readFileSync(join(dir, "42"), "utf8"));
 	expect(m.type).toBe("notify");
 	expect(m.label).toBe("answer me");
@@ -67,41 +66,42 @@ test("event: a bare string state is accepted", async () => {
 	const dir = freshDir("wez-evtstr-");
 	process.env.WEZTERM_PANE = "42";
 	const { eventHandler } = loadExt();
-	eventHandler("review");
-	await sleep(20);
+	await eventHandler("review");
 	expect(JSON.parse(readFileSync(join(dir, "42"), "utf8")).type).toBe("review");
 	rmSync(dir, { recursive: true, force: true });
 });
 
-test("F1: last requested mutation wins — notify then clear leaves NO marker", async () => {
+test("ordering: notify then clear leaves NO marker (last requested wins)", async () => {
 	const dir = freshDir("wez-order1-");
 	process.env.WEZTERM_PANE = "42";
 	const { eventHandler } = loadExt();
 	let present = 0;
 	for (let i = 0; i < 30; i++) {
-		eventHandler("notify");
-		eventHandler("clear");
-		await sleep(10);
+		// Emit both before either settles (exercise the interleaving), then await
+		// both deterministically — no sleep, so the assertion can't run early.
+		const a = eventHandler("notify");
+		const b = eventHandler("clear");
+		await Promise.all([a, b]);
 		if (existsSync(join(dir, "42"))) present++;
 	}
 	expect(present).toBe(0);
 	rmSync(dir, { recursive: true, force: true });
 });
 
-test("F1: ordering preserved — clear then notify leaves a notify marker", async () => {
+test("ordering: clear then notify leaves a notify marker", async () => {
 	const dir = freshDir("wez-order2-");
 	process.env.WEZTERM_PANE = "42";
 	const { eventHandler } = loadExt();
 	writeFileSync(join(dir, "42"), "{}");
-	eventHandler("clear");
-	eventHandler("notify");
-	await sleep(20);
+	const a = eventHandler("clear");
+	const b = eventHandler("notify");
+	await Promise.all([a, b]);
 	expect(existsSync(join(dir, "42"))).toBe(true);
 	expect(JSON.parse(readFileSync(join(dir, "42"), "utf8")).type).toBe("notify");
 	rmSync(dir, { recursive: true, force: true });
 });
 
-test("F4: a traversal pane id writes NOTHING outside the marker dir", async () => {
+test("traversal: a bad pane id writes NOTHING outside the marker dir", async () => {
 	const parent = mkdtempSync(join(tmpdir(), "wez-trav1-"));
 	const dir = join(parent, "markerdir");
 	mkdirSync(dir);
@@ -110,13 +110,12 @@ test("F4: a traversal pane id writes NOTHING outside the marker dir", async () =
 	process.env.WEZTERM_ATTENTION_DIR = dir;
 	process.env.WEZTERM_PANE = "../victim.txt";
 	const { eventHandler } = loadExt();
-	eventHandler("notify");
-	await sleep(20);
+	await eventHandler("notify");
 	expect(readFileSync(victim, "utf8")).toBe("IMPORTANT"); // untouched
 	rmSync(parent, { recursive: true, force: true });
 });
 
-test("F4: a traversal pane id does NOT delete an outside file on clear", async () => {
+test("traversal: a bad pane id does NOT delete an outside file on clear", async () => {
 	const parent = mkdtempSync(join(tmpdir(), "wez-trav2-"));
 	const dir = join(parent, "markerdir");
 	mkdirSync(dir);
@@ -125,10 +124,20 @@ test("F4: a traversal pane id does NOT delete an outside file on clear", async (
 	process.env.WEZTERM_ATTENTION_DIR = dir;
 	process.env.WEZTERM_PANE = "../victim.txt";
 	const { eventHandler } = loadExt();
-	eventHandler("clear");
-	await sleep(20);
+	await eventHandler("clear");
 	expect(existsSync(victim)).toBe(true); // not deleted
 	rmSync(parent, { recursive: true, force: true });
+});
+
+test("cleanup: a failed rename does not leak temp files", async () => {
+	const dir = freshDir("wez-leak-");
+	process.env.WEZTERM_PANE = "42";
+	mkdirSync(join(dir, "42")); // marker path is a directory → rename fails
+	const { eventHandler } = loadExt();
+	for (let i = 0; i < 10; i++) await eventHandler("notify");
+	const leaked = readdirSync(dir).filter((f) => f.includes(".tmp."));
+	expect(leaked.length).toBe(0);
+	rmSync(dir, { recursive: true, force: true });
 });
 
 test("missing pane: lifecycle write is a silent no-op, no throw", async () => {

--- a/tests/pi_extension.test.ts
+++ b/tests/pi_extension.test.ts
@@ -95,6 +95,7 @@ test("lifecycle: agent_start writes a thinking marker with ttl_ms, updated_at, s
 	process.env.WEZTERM_PANE = "42";
 	const { lifecycle } = loadExt();
 	await lifecycle["agent_start"]!();
+	await lifecycle["session_shutdown"]!(); // lifecycle no longer awaits I/O; drain it
 	const m = readMarker(dir);
 	expect(m.type).toBe("thinking");
 	expect(m.source).toBe("pi");
@@ -107,6 +108,7 @@ test("lifecycle: tool_execution_start writes a thinking marker", async () => {
 	process.env.WEZTERM_PANE = "42";
 	const { lifecycle } = loadExt();
 	await lifecycle["tool_execution_start"]!();
+	await lifecycle["session_shutdown"]!(); // lifecycle no longer awaits I/O; drain it
 	expect(readMarker(dir).type).toBe("thinking");
 });
 
@@ -119,9 +121,34 @@ test("lifecycle: agent_settled — not agent_end — writes the stop marker", as
 	const { lifecycle } = loadExt();
 	expect(lifecycle["agent_end"]).toBeUndefined();
 	await lifecycle["agent_settled"]!();
+	await lifecycle["session_shutdown"]!(); // lifecycle no longer awaits I/O; drain it
 	const m = readMarker(dir);
 	expect(m.type).toBe("stop");
 	expect(m.ttl_ms).toBeUndefined();
+});
+
+test("lifecycle: handlers return before marker I/O lands (no agent-critical-path await)", async () => {
+	// Pi awaits lifecycle handlers on the agent's OWN critical path:
+	//   agent-loop.ts  await emit("tool_execution_start")  → then prepares the tool call
+	//   agent.ts       for (listener of listeners) await listener(event, signal)   (serial, no timeout)
+	//   agent-session.ts  await this._emitExtensionEvent(event)  → before the TUI notify
+	//   runner.ts      await handler(event, ctx)
+	// So awaiting a marker write here puts the filesystem in the agent's latency
+	// budget, and on a mount whose syscalls block forever it wedges the host: one
+	// stuck op parks every later lifecycle event (shared serial chain), the TUI never
+	// sees the event, and abort cannot release a parked await. Headless is worse —
+	// `_resolveIdleWaitIfIdle()` lives in a `finally` whose `try` awaits this emit, so
+	// `pi -p` never terminates.
+	//
+	// Both assertions carry weight: the first locks OUT restoring the await, the
+	// second locks IN that the write is deferred rather than dropped.
+	const dir = freshDir("wez-nocritpath-");
+	process.env.WEZTERM_PANE = "42";
+	const { lifecycle } = loadExt();
+	await lifecycle["agent_start"]!();
+	expect(existsSync(join(dir, "42"))).toBe(false); // returned without waiting on I/O
+	await lifecycle["session_shutdown"]!();
+	expect(existsSync(join(dir, "42"))).toBe(true); // ...and the write still lands
 });
 
 test("registration: the extension listens on the wezterm-attention:mark channel", () => {
@@ -306,6 +333,7 @@ test("missing pane: lifecycle write is a silent no-op that creates no file", asy
 	delete process.env.WEZTERM_PANE; // the condition under test, not teardown
 	const { lifecycle } = loadExt();
 	await lifecycle["agent_start"]!();
+	await lifecycle["session_shutdown"]!(); // lifecycle no longer awaits I/O; drain it
 	expect(readdirSync(dir).length).toBe(0); // nothing written at all, not merely no "undefined" file
 });
 
@@ -317,6 +345,7 @@ test('env: a unit-suffixed TTL ("30m") is rejected, not parsed as 30', async () 
 	process.env.PI_WEZTERM_ATTENTION_TTL_MS = "30m";
 	const { lifecycle } = loadExt();
 	await lifecycle["agent_start"]!();
+	await lifecycle["session_shutdown"]!(); // lifecycle no longer awaits I/O; drain it
 	const m = readMarker(dir);
 	expect(m.ttl_ms).toBe(30 * 60 * 1000); // default, NOT 30
 });
@@ -330,6 +359,7 @@ test("env: a relative WEZTERM_ATTENTION_DIR is rejected (no cwd scatter, no cwd 
 	process.env.WEZTERM_PANE = "42";
 	const { lifecycle, emit } = loadExt();
 	await lifecycle["agent_start"]!(); // write path: guarded → no file created
+	await lifecycle["session_shutdown"]!(); // lifecycle no longer awaits I/O; drain it
 	await emit("clear"); // clear path shares the same guard → no rm of a cwd file
 	expect(existsSync(join(relDir, "42"))).toBe(false);
 	expect(existsSync(relDir)).toBe(false); // dir never even created
@@ -345,6 +375,7 @@ test('env: TTL_MS="0" falls back to the default, not an instantly-stale marker',
 	process.env.PI_WEZTERM_ATTENTION_TTL_MS = "0";
 	const { lifecycle } = loadExt();
 	await lifecycle["agent_start"]!();
+	await lifecycle["session_shutdown"]!(); // lifecycle no longer awaits I/O; drain it
 	const m = readMarker(dir);
 	expect(m.ttl_ms).toBe(30 * 60 * 1000); // default, NOT 0
 });

--- a/tests/pi_extension.test.ts
+++ b/tests/pi_extension.test.ts
@@ -3,23 +3,56 @@
 // lock — several are the negation of a bug fixed during review triage.
 // Mutations are awaited deterministically (the event handler returns its queue
 // promise), never slept on. Run: `bun test`.
+//
+// The mock event bus models the real one (node:events under the hood): `on`
+// appends a handler and returns a disposer that removes it, and `emit` invokes
+// every current handler.
+//
+// Fidelity caveat: `loadExt().load()` re-invokes the default export against the
+// SAME module scope, so it exercises re-registration but NOT a cache-cleared
+// generation with a fresh `mutationChain`. The "reload (real module re-eval)"
+// test below covers genuine module re-evaluation via `import(...?gen=N)`; that
+// one is what actually locks retire-at-registration against the WeakMap-scope
+// and key-choice regressions.
 import { test, expect } from "bun:test";
 import { mkdtempSync, mkdirSync, existsSync, readFileSync, readdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import ext from "../pi/index.ts";
 
+type Handler = (data: unknown) => void | Promise<void>;
+
 function loadExt() {
 	const lifecycle: Record<string, () => Promise<void> | void> = {};
-	let eventHandler: (data: unknown) => void | Promise<void> = () => {};
+	const handlers: Handler[] = [];
+	const channels: string[] = [];
+	let commandCalls = 0;
 	const pi = {
-		events: { on: (_e: string, h: (d: unknown) => void | Promise<void>) => { eventHandler = h; } },
-		on: (event: string, h: () => Promise<void> | void) => { lifecycle[event] = h; },
-		registerCommand: () => {},
+		events: {
+			on: (channel: string, h: Handler) => {
+				channels.push(channel);
+				handlers.push(h);
+				return () => {
+					const i = handlers.indexOf(h);
+					if (i >= 0) handlers.splice(i, 1);
+				};
+			},
+		},
+		on: (event: string, h: () => Promise<void> | void) => {
+			lifecycle[event] = h;
+		},
+		registerCommand: () => {
+			commandCalls++;
+		},
 	};
-	// deno-lint-ignore no-explicit-any
-	ext(pi as any);
-	return { lifecycle, eventHandler };
+	// load() re-invokes the extension's default export against the SAME pi — the
+	// in-process stand-in for a fresh extension instance after Pi's /reload.
+	const load = () => ext(pi as any);
+	// emit() fans a payload out to every registered event handler, mirroring the
+	// real bus, and awaits them so assertions never run before the write settles.
+	const emit = (data: unknown) => Promise.all(handlers.map((h) => h(data)));
+	load();
+	return { lifecycle, emit, load, handlers, channels, commandCount: () => commandCalls };
 }
 
 function freshDir(prefix: string): string {
@@ -28,7 +61,7 @@ function freshDir(prefix: string): string {
 	return d;
 }
 
-test("lifecycle: agent_start writes a thinking marker with ttl_ms and source pi", async () => {
+test("lifecycle: agent_start writes a thinking marker with ttl_ms, updated_at, source pi", async () => {
 	const dir = freshDir("wez-life1-");
 	process.env.WEZTERM_PANE = "42";
 	const { lifecycle } = loadExt();
@@ -37,25 +70,51 @@ test("lifecycle: agent_start writes a thinking marker with ttl_ms and source pi"
 	expect(m.type).toBe("thinking");
 	expect(m.source).toBe("pi");
 	expect(typeof m.ttl_ms).toBe("number");
+	expect(typeof m.updated_at).toBe("number"); // locks the contract field bun won't typecheck
 	rmSync(dir, { recursive: true, force: true });
 });
 
-test("lifecycle: agent_end writes a stop marker (no ttl_ms)", async () => {
-	const dir = freshDir("wez-life2-");
+test("lifecycle: tool_execution_start writes a thinking marker", async () => {
+	const dir = freshDir("wez-tool-");
 	process.env.WEZTERM_PANE = "42";
 	const { lifecycle } = loadExt();
-	await lifecycle["agent_end"]!();
+	await lifecycle["tool_execution_start"]!();
+	expect(JSON.parse(readFileSync(join(dir, "42"), "utf8")).type).toBe("thinking");
+	rmSync(dir, { recursive: true, force: true });
+});
+
+test("lifecycle: agent_settled — not agent_end — writes the stop marker", async () => {
+	// agent_end is nonterminal (auto-retry/compaction can follow); only
+	// agent_settled means Pi is truly done, so `stop` must hang off it. Assert
+	// agent_end is NOT even registered, so a false mid-run ✓ is impossible.
+	const dir = freshDir("wez-settled-");
+	process.env.WEZTERM_PANE = "42";
+	const { lifecycle } = loadExt();
+	expect(lifecycle["agent_end"]).toBeUndefined();
+	await lifecycle["agent_settled"]!();
 	const m = JSON.parse(readFileSync(join(dir, "42"), "utf8"));
 	expect(m.type).toBe("stop");
 	expect(m.ttl_ms).toBeUndefined();
 	rmSync(dir, { recursive: true, force: true });
 });
 
+test("registration: the extension listens on the wezterm-attention:mark channel", () => {
+	freshDir("wez-chan-");
+	const { channels } = loadExt();
+	expect(channels).toContain("wezterm-attention:mark");
+});
+
+test("registration: the extension registers no commands", () => {
+	freshDir("wez-nocmd-");
+	const { commandCount } = loadExt();
+	expect(commandCount()).toBe(0);
+});
+
 test("event: emitting a notify object writes a labeled notify marker", async () => {
 	const dir = freshDir("wez-evt-");
 	process.env.WEZTERM_PANE = "42";
-	const { eventHandler } = loadExt();
-	await eventHandler({ type: "notify", label: "answer me" });
+	const { emit } = loadExt();
+	await emit({ type: "notify", label: "answer me" });
 	const m = JSON.parse(readFileSync(join(dir, "42"), "utf8"));
 	expect(m.type).toBe("notify");
 	expect(m.label).toBe("answer me");
@@ -65,8 +124,8 @@ test("event: emitting a notify object writes a labeled notify marker", async () 
 test("event: a bare string state is accepted", async () => {
 	const dir = freshDir("wez-evtstr-");
 	process.env.WEZTERM_PANE = "42";
-	const { eventHandler } = loadExt();
-	await eventHandler("review");
+	const { emit } = loadExt();
+	await emit("review");
 	expect(JSON.parse(readFileSync(join(dir, "42"), "utf8")).type).toBe("review");
 	rmSync(dir, { recursive: true, force: true });
 });
@@ -74,13 +133,13 @@ test("event: a bare string state is accepted", async () => {
 test("ordering: notify then clear leaves NO marker (last requested wins)", async () => {
 	const dir = freshDir("wez-order1-");
 	process.env.WEZTERM_PANE = "42";
-	const { eventHandler } = loadExt();
+	const { emit } = loadExt();
 	let present = 0;
 	for (let i = 0; i < 30; i++) {
 		// Emit both before either settles (exercise the interleaving), then await
 		// both deterministically — no sleep, so the assertion can't run early.
-		const a = eventHandler("notify");
-		const b = eventHandler("clear");
+		const a = emit("notify");
+		const b = emit("clear");
 		await Promise.all([a, b]);
 		if (existsSync(join(dir, "42"))) present++;
 	}
@@ -91,13 +150,82 @@ test("ordering: notify then clear leaves NO marker (last requested wins)", async
 test("ordering: clear then notify leaves a notify marker", async () => {
 	const dir = freshDir("wez-order2-");
 	process.env.WEZTERM_PANE = "42";
-	const { eventHandler } = loadExt();
+	const { emit } = loadExt();
 	writeFileSync(join(dir, "42"), "{}");
-	const a = eventHandler("clear");
-	const b = eventHandler("notify");
+	const a = emit("clear");
+	const b = emit("notify");
 	await Promise.all([a, b]);
 	expect(existsSync(join(dir, "42"))).toBe(true);
 	expect(JSON.parse(readFileSync(join(dir, "42"), "utf8")).type).toBe("notify");
+	rmSync(dir, { recursive: true, force: true });
+});
+
+test("reload (real module re-eval): retire-at-registration collapses N fresh generations to one listener", async () => {
+	// Genuine reload semantics: each generation is a re-evaluated module (fresh
+	// module scope / fresh mutationChain), sharing ONE bus, all seeing the same
+	// globalThis WeakMap — which the same-instance harness can't reproduce. This
+	// is the test that goes red if the registry is module-level instead of
+	// globalThis, or keyed on `pi` instead of `pi.events`.
+	const handlers: Array<(d: unknown) => unknown> = [];
+	const bus = {
+		on: (_ch: string, h: (d: unknown) => unknown) => {
+			handlers.push(h);
+			return () => {
+				const i = handlers.indexOf(h);
+				if (i >= 0) handlers.splice(i, 1);
+			};
+		},
+	};
+	const makePi = () => ({ events: bus, on: () => {}, registerCommand: () => {} });
+	for (let gen = 0; gen < 4; gen++) {
+		const mod = await import(`../pi/index.ts?realreload=${gen}`);
+		mod.default(makePi() as any);
+	}
+	expect(handlers.length).toBe(1); // all four generations collapsed to one live listener
+});
+
+test("reload: a new generation retires the previous listener (no accumulation)", async () => {
+	// Same-instance re-registration (see the fidelity caveat at the top): covers
+	// the re-register path; the real-module-re-eval test above covers cross-gen.
+	const dir = freshDir("wez-reload-");
+	process.env.WEZTERM_PANE = "42";
+	const h = loadExt();
+	expect(h.handlers.length).toBe(1); // gen-0 registered exactly one listener
+	h.load(); // gen-1 registers and retires gen-0's listener
+	expect(h.handlers.length).toBe(1); // one, not stacked
+	h.load(); // gen-2
+	expect(h.handlers.length).toBe(1);
+	await Promise.all([h.emit("notify"), h.emit("clear")]);
+	expect(existsSync(join(dir, "42"))).toBe(false);
+	rmSync(dir, { recursive: true, force: true });
+});
+
+test("failed reload: session_shutdown does NOT dispose the listener", async () => {
+	// reload() emits session_shutdown BEFORE its fallible work, and a reload
+	// failure keeps the session running (handleReloadCommand catches it). So
+	// disposing on shutdown would silence notify with no successor. Shutdown must
+	// only drain — the listener stays live.
+	const dir = freshDir("wez-failreload-");
+	process.env.WEZTERM_PANE = "42";
+	const h = loadExt();
+	expect(typeof h.lifecycle["session_shutdown"]).toBe("function");
+	await h.lifecycle["session_shutdown"]!(); // shutdown fires, then imagine reload throws
+	expect(h.handlers.length).toBe(1); // listener still live
+	await h.emit("notify"); // cooperative path still works
+	expect(existsSync(join(dir, "42"))).toBe(true);
+	rmSync(dir, { recursive: true, force: true });
+});
+
+test("session_shutdown drains in-flight writes before returning", async () => {
+	// The drain is what closes the cross-reload write race — locked separately so
+	// removing `await mutationChain` turns the suite red.
+	const dir = freshDir("wez-drain-");
+	process.env.WEZTERM_PANE = "42";
+	const h = loadExt();
+	const pending = h.emit("notify"); // in-flight; deliberately not awaited here
+	await h.lifecycle["session_shutdown"]!(); // must not return until `pending` settles
+	expect(existsSync(join(dir, "42"))).toBe(true); // drained → write landed
+	await pending;
 	rmSync(dir, { recursive: true, force: true });
 });
 
@@ -109,8 +237,8 @@ test("traversal: a bad pane id writes NOTHING outside the marker dir", async () 
 	writeFileSync(victim, "IMPORTANT");
 	process.env.WEZTERM_ATTENTION_DIR = dir;
 	process.env.WEZTERM_PANE = "../victim.txt";
-	const { eventHandler } = loadExt();
-	await eventHandler("notify");
+	const { emit } = loadExt();
+	await emit("notify");
 	expect(readFileSync(victim, "utf8")).toBe("IMPORTANT"); // untouched
 	rmSync(parent, { recursive: true, force: true });
 });
@@ -123,8 +251,8 @@ test("traversal: a bad pane id does NOT delete an outside file on clear", async 
 	writeFileSync(victim, "IMPORTANT");
 	process.env.WEZTERM_ATTENTION_DIR = dir;
 	process.env.WEZTERM_PANE = "../victim.txt";
-	const { eventHandler } = loadExt();
-	await eventHandler("clear");
+	const { emit } = loadExt();
+	await emit("clear");
 	expect(existsSync(victim)).toBe(true); // not deleted
 	rmSync(parent, { recursive: true, force: true });
 });
@@ -133,18 +261,48 @@ test("cleanup: a failed rename does not leak temp files", async () => {
 	const dir = freshDir("wez-leak-");
 	process.env.WEZTERM_PANE = "42";
 	mkdirSync(join(dir, "42")); // marker path is a directory → rename fails
-	const { eventHandler } = loadExt();
-	for (let i = 0; i < 10; i++) await eventHandler("notify");
+	const { emit } = loadExt();
+	for (let i = 0; i < 10; i++) await emit("notify");
 	const leaked = readdirSync(dir).filter((f) => f.includes(".tmp."));
 	expect(leaked.length).toBe(0);
 	rmSync(dir, { recursive: true, force: true });
 });
 
-test("missing pane: lifecycle write is a silent no-op, no throw", async () => {
+test("missing pane: lifecycle write is a silent no-op that creates no file", async () => {
 	const dir = freshDir("wez-nopane-");
 	delete process.env.WEZTERM_PANE;
 	const { lifecycle } = loadExt();
 	await lifecycle["agent_start"]!();
-	expect(existsSync(join(dir, "undefined"))).toBe(false);
+	expect(readdirSync(dir).length).toBe(0); // nothing written at all, not merely no "undefined" file
 	rmSync(dir, { recursive: true, force: true });
+});
+
+test('env: a unit-suffixed TTL ("30m") is rejected, not parsed as 30', async () => {
+	// F7: parseInt("30m") === 30 silently produced a 30ms TTL. Strict parse must
+	// reject it and fall back to the 30-minute default.
+	const dir = freshDir("wez-ttl-");
+	process.env.WEZTERM_PANE = "42";
+	process.env.PI_WEZTERM_ATTENTION_TTL_MS = "30m";
+	const { lifecycle } = loadExt();
+	await lifecycle["agent_start"]!();
+	const m = JSON.parse(readFileSync(join(dir, "42"), "utf8"));
+	expect(m.ttl_ms).toBe(30 * 60 * 1000); // default, NOT 30
+	delete process.env.PI_WEZTERM_ATTENTION_TTL_MS;
+	rmSync(dir, { recursive: true, force: true });
+});
+
+test("env: a relative WEZTERM_ATTENTION_DIR is rejected (no cwd scatter, no cwd delete)", async () => {
+	// F2: markerDirectory requires an absolute result. A relative override would
+	// otherwise write markers under cwd (scatter) and let clear rm() a cwd file.
+	const relDir = join(process.cwd(), "wez-rel-marker-dir");
+	rmSync(relDir, { recursive: true, force: true });
+	process.env.WEZTERM_ATTENTION_DIR = "wez-rel-marker-dir";
+	process.env.WEZTERM_PANE = "42";
+	const { lifecycle, emit } = loadExt();
+	await lifecycle["agent_start"]!(); // write path: guarded → no file created
+	await emit("clear"); // clear path shares the same guard → no rm of a cwd file
+	expect(existsSync(join(relDir, "42"))).toBe(false);
+	expect(existsSync(relDir)).toBe(false); // dir never even created
+	rmSync(relDir, { recursive: true, force: true });
+	delete process.env.WEZTERM_ATTENTION_DIR;
 });

--- a/tests/pi_extension.test.ts
+++ b/tests/pi_extension.test.ts
@@ -166,22 +166,32 @@ test("reload (real module re-eval): retire-at-registration collapses N fresh gen
 	// globalThis WeakMap — which the same-instance harness can't reproduce. This
 	// is the test that goes red if the registry is module-level instead of
 	// globalThis, or keyed on `pi` instead of `pi.events`.
-	const handlers: Array<(d: unknown) => unknown> = [];
+	// Handlers are tagged with the generation that registered them, because
+	// cardinality alone does not lock the property this test exists for: a mutant
+	// that disposes ITSELF instead of its predecessor (`if (prev) disposeEvent()`
+	// rather than `prev?.()` — two same-typed locals on adjacent lines) also leaves
+	// exactly one listener, but it is generation 0's, live forever, while every
+	// later reload silently registers and immediately retires itself.
+	const handlers: Array<{ gen: number; h: (d: unknown) => unknown }> = [];
+	let currentGen = -1;
 	const bus = {
 		on: (_ch: string, h: (d: unknown) => unknown) => {
-			handlers.push(h);
+			const entry = { gen: currentGen, h };
+			handlers.push(entry);
 			return () => {
-				const i = handlers.indexOf(h);
+				const i = handlers.indexOf(entry);
 				if (i >= 0) handlers.splice(i, 1);
 			};
 		},
 	};
 	const makePi = () => ({ events: bus, on: () => {}, registerCommand: () => {} });
 	for (let gen = 0; gen < 4; gen++) {
+		currentGen = gen;
 		const mod = await import(`../pi/index.ts?realreload=${gen}`);
 		mod.default(makePi() as any);
 	}
 	expect(handlers.length).toBe(1); // all four generations collapsed to one live listener
+	expect(handlers.map((e) => e.gen)).toEqual([3]); // and the survivor is the NEWEST one
 });
 
 test("reload: a new generation retires the previous listener (no accumulation)", async () => {
@@ -305,4 +315,58 @@ test("env: a relative WEZTERM_ATTENTION_DIR is rejected (no cwd scatter, no cwd 
 	expect(existsSync(relDir)).toBe(false); // dir never even created
 	rmSync(relDir, { recursive: true, force: true });
 	delete process.env.WEZTERM_ATTENTION_DIR;
+});
+
+test('env: TTL_MS="0" falls back to the default, not an instantly-stale marker', async () => {
+	// "0" is a plausible "disable the TTL" reading, and it passes the digits-only
+	// gate — only the `parsed > 0` range check rejects it. Without that check the
+	// marker ships ttl_ms: 0 and plugin/init.lua expires the spinner immediately.
+	const dir = freshDir("wez-ttl0-");
+	process.env.WEZTERM_PANE = "42";
+	process.env.PI_WEZTERM_ATTENTION_TTL_MS = "0";
+	const { lifecycle } = loadExt();
+	await lifecycle["agent_start"]!();
+	const m = JSON.parse(readFileSync(join(dir, "42"), "utf8"));
+	expect(m.ttl_ms).toBe(30 * 60 * 1000); // default, NOT 0
+	delete process.env.PI_WEZTERM_ATTENTION_TTL_MS;
+	rmSync(dir, { recursive: true, force: true });
+});
+
+// The alias table README.md advertises to other extension authors. It is a public
+// cross-extension contract, so every row is locked here rather than left to the
+// lifecycle path (which only ever calls mark("thinking"|"stop") directly and so
+// exercises none of the mapping).
+const ALIAS_CASES: Array<[string, string]> = [
+	["busy", "thinking"],
+	["thinking", "thinking"],
+	["ready", "stop"],
+	["stop", "stop"],
+	["blocked", "notify"],
+	["pending", "notify"],
+	["notify", "notify"],
+	["review", "review"],
+];
+
+test("event: every documented alias maps to its canonical marker state", async () => {
+	for (const [alias, expected] of ALIAS_CASES) {
+		const dir = freshDir("wez-alias-");
+		process.env.WEZTERM_PANE = "42";
+		const h = loadExt();
+		await h.emit(alias);
+		const m = JSON.parse(readFileSync(join(dir, "42"), "utf8"));
+		expect(m.type).toBe(expected); // `${alias}` → `${expected}`
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+test("event: an unrecognized state is rejected, writing nothing", async () => {
+	// normalizeState's `default: undefined` is the gate. Without it an arbitrary
+	// string reaches disk as {"type":"bogus"} — litter the plugin's valid_types
+	// table ignores, but litter this writer should never produce.
+	const dir = freshDir("wez-bogus-");
+	process.env.WEZTERM_PANE = "42";
+	const h = loadExt();
+	await h.emit("bogus");
+	expect(readdirSync(dir).length).toBe(0);
+	rmSync(dir, { recursive: true, force: true });
 });

--- a/tests/pi_extension.test.ts
+++ b/tests/pi_extension.test.ts
@@ -1,27 +1,24 @@
-// Regression tests for pi/index.ts, driving the REAL registered command/event
-// handlers through a mock ExtensionAPI. Named after the properties they lock —
-// several are the negation of a bug fixed during review triage. Run: `bun test`.
+// Regression tests for pi/index.ts, driving the REAL registered lifecycle and
+// event handlers through a mock ExtensionAPI. Named after the properties they
+// lock — several are the negation of a bug fixed during review triage.
+// Run: `bun test`.
 import { test, expect } from "bun:test";
-import { mkdtempSync, mkdirSync, existsSync, readFileSync, writeFileSync, chmodSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, existsSync, readFileSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import ext from "../pi/index.ts";
 
-type Note = { msg: string; level: string };
-
 function loadExt() {
-	let cmdHandler!: (args: string, ctx: { ui: { notify: (m: string, l: string) => void } }) => Promise<void>;
-	let eventHandler!: (data: unknown) => void;
-	const notes: Note[] = [];
+	const lifecycle: Record<string, () => Promise<void> | void> = {};
+	let eventHandler: (data: unknown) => void = () => {};
 	const pi = {
 		events: { on: (_e: string, h: (d: unknown) => void) => { eventHandler = h; } },
-		on: () => {},
-		registerCommand: (_n: string, o: { handler: typeof cmdHandler }) => { cmdHandler = o.handler; },
+		on: (event: string, h: () => Promise<void> | void) => { lifecycle[event] = h; },
+		registerCommand: () => {},
 	};
 	// deno-lint-ignore no-explicit-any
 	ext(pi as any);
-	const ctx = { ui: { notify: (msg: string, level: string) => notes.push({ msg, level }) } };
-	return { cmdHandler, eventHandler, notes, ctx };
+	return { lifecycle, eventHandler };
 }
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
@@ -31,18 +28,48 @@ function freshDir(prefix: string): string {
 	return d;
 }
 
-test("happy path: /attention busy writes a thinking marker with ttl_ms and source pi", async () => {
-	const dir = freshDir("wez-happy-");
+test("lifecycle: agent_start writes a thinking marker with ttl_ms and source pi", async () => {
+	const dir = freshDir("wez-life1-");
 	process.env.WEZTERM_PANE = "42";
-	const { cmdHandler, notes } = loadExt();
-	await cmdHandler("busy label here", { ui: { notify: (m, l) => notes.push({ msg: m, level: l }) } });
+	const { lifecycle } = loadExt();
+	await lifecycle["agent_start"]!();
 	const m = JSON.parse(readFileSync(join(dir, "42"), "utf8"));
 	expect(m.type).toBe("thinking");
 	expect(m.source).toBe("pi");
 	expect(typeof m.ttl_ms).toBe("number");
-	expect(m.label).toBe("label here");
-	// The message reports the resolved state (busy -> thinking), pre-existing behavior.
-	expect(notes.at(-1)?.msg).toBe("Marked WezTerm pane as thinking");
+	rmSync(dir, { recursive: true, force: true });
+});
+
+test("lifecycle: agent_end writes a stop marker (no ttl_ms)", async () => {
+	const dir = freshDir("wez-life2-");
+	process.env.WEZTERM_PANE = "42";
+	const { lifecycle } = loadExt();
+	await lifecycle["agent_end"]!();
+	const m = JSON.parse(readFileSync(join(dir, "42"), "utf8"));
+	expect(m.type).toBe("stop");
+	expect(m.ttl_ms).toBeUndefined();
+	rmSync(dir, { recursive: true, force: true });
+});
+
+test("event: emitting a notify object writes a labeled notify marker", async () => {
+	const dir = freshDir("wez-evt-");
+	process.env.WEZTERM_PANE = "42";
+	const { eventHandler } = loadExt();
+	eventHandler({ type: "notify", label: "answer me" });
+	await sleep(20);
+	const m = JSON.parse(readFileSync(join(dir, "42"), "utf8"));
+	expect(m.type).toBe("notify");
+	expect(m.label).toBe("answer me");
+	rmSync(dir, { recursive: true, force: true });
+});
+
+test("event: a bare string state is accepted", async () => {
+	const dir = freshDir("wez-evtstr-");
+	process.env.WEZTERM_PANE = "42";
+	const { eventHandler } = loadExt();
+	eventHandler("review");
+	await sleep(20);
+	expect(JSON.parse(readFileSync(join(dir, "42"), "utf8")).type).toBe("review");
 	rmSync(dir, { recursive: true, force: true });
 });
 
@@ -74,31 +101,7 @@ test("F1: ordering preserved — clear then notify leaves a notify marker", asyn
 	rmSync(dir, { recursive: true, force: true });
 });
 
-test("F3: filesystem failure reports io-error, NOT 'not set', when the pane IS set", async () => {
-	const parent = mkdtempSync(join(tmpdir(), "wez-io-"));
-	const dir = join(parent, "markers");
-	mkdirSync(dir);
-	chmodSync(dir, 0o500); // no write
-	process.env.WEZTERM_ATTENTION_DIR = dir;
-	process.env.WEZTERM_PANE = "42";
-	const { cmdHandler, notes } = loadExt();
-	await cmdHandler("notify", { ui: { notify: (m, l) => notes.push({ msg: m, level: l }) } });
-	const msg = notes.at(-1)?.msg ?? "";
-	expect(msg).toContain("I/O error");
-	expect(msg).not.toContain("not set");
-	chmodSync(dir, 0o700);
-	rmSync(parent, { recursive: true, force: true });
-});
-
-test("F3: missing pane still reports 'not set' (unchanged truthful behavior)", async () => {
-	freshDir("wez-missing-");
-	delete process.env.WEZTERM_PANE;
-	const { cmdHandler, notes } = loadExt();
-	await cmdHandler("notify", { ui: { notify: (m, l) => notes.push({ msg: m, level: l }) } });
-	expect(notes.at(-1)?.msg).toBe("WEZTERM_PANE is not set; nothing written");
-});
-
-test("F4: traversal pane id writes NOTHING outside the marker dir and is rejected", async () => {
+test("F4: a traversal pane id writes NOTHING outside the marker dir", async () => {
 	const parent = mkdtempSync(join(tmpdir(), "wez-trav1-"));
 	const dir = join(parent, "markerdir");
 	mkdirSync(dir);
@@ -106,14 +109,14 @@ test("F4: traversal pane id writes NOTHING outside the marker dir and is rejecte
 	writeFileSync(victim, "IMPORTANT");
 	process.env.WEZTERM_ATTENTION_DIR = dir;
 	process.env.WEZTERM_PANE = "../victim.txt";
-	const { cmdHandler, notes } = loadExt();
-	await cmdHandler("busy", { ui: { notify: (m, l) => notes.push({ msg: m, level: l }) } });
+	const { eventHandler } = loadExt();
+	eventHandler("notify");
+	await sleep(20);
 	expect(readFileSync(victim, "utf8")).toBe("IMPORTANT"); // untouched
-	expect(notes.at(-1)?.msg).toContain("not a valid pane id");
 	rmSync(parent, { recursive: true, force: true });
 });
 
-test("F4: /attention clear with a traversal pane id does NOT delete an outside file", async () => {
+test("F4: a traversal pane id does NOT delete an outside file on clear", async () => {
 	const parent = mkdtempSync(join(tmpdir(), "wez-trav2-"));
 	const dir = join(parent, "markerdir");
 	mkdirSync(dir);
@@ -121,8 +124,18 @@ test("F4: /attention clear with a traversal pane id does NOT delete an outside f
 	writeFileSync(victim, "IMPORTANT");
 	process.env.WEZTERM_ATTENTION_DIR = dir;
 	process.env.WEZTERM_PANE = "../victim.txt";
-	const { cmdHandler } = loadExt();
-	await cmdHandler("clear", { ui: { notify: () => {} } });
+	const { eventHandler } = loadExt();
+	eventHandler("clear");
+	await sleep(20);
 	expect(existsSync(victim)).toBe(true); // not deleted
 	rmSync(parent, { recursive: true, force: true });
+});
+
+test("missing pane: lifecycle write is a silent no-op, no throw", async () => {
+	const dir = freshDir("wez-nopane-");
+	delete process.env.WEZTERM_PANE;
+	const { lifecycle } = loadExt();
+	await lifecycle["agent_start"]!();
+	expect(existsSync(join(dir, "undefined"))).toBe(false);
+	rmSync(dir, { recursive: true, force: true });
 });

--- a/tests/pi_extension.test.ts
+++ b/tests/pi_extension.test.ts
@@ -1,0 +1,128 @@
+// Regression tests for pi/index.ts, driving the REAL registered command/event
+// handlers through a mock ExtensionAPI. Named after the properties they lock —
+// several are the negation of a bug fixed during review triage. Run: `bun test`.
+import { test, expect } from "bun:test";
+import { mkdtempSync, mkdirSync, existsSync, readFileSync, writeFileSync, chmodSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import ext from "../pi/index.ts";
+
+type Note = { msg: string; level: string };
+
+function loadExt() {
+	let cmdHandler!: (args: string, ctx: { ui: { notify: (m: string, l: string) => void } }) => Promise<void>;
+	let eventHandler!: (data: unknown) => void;
+	const notes: Note[] = [];
+	const pi = {
+		events: { on: (_e: string, h: (d: unknown) => void) => { eventHandler = h; } },
+		on: () => {},
+		registerCommand: (_n: string, o: { handler: typeof cmdHandler }) => { cmdHandler = o.handler; },
+	};
+	// deno-lint-ignore no-explicit-any
+	ext(pi as any);
+	const ctx = { ui: { notify: (msg: string, level: string) => notes.push({ msg, level }) } };
+	return { cmdHandler, eventHandler, notes, ctx };
+}
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+function freshDir(prefix: string): string {
+	const d = mkdtempSync(join(tmpdir(), prefix));
+	process.env.WEZTERM_ATTENTION_DIR = d;
+	return d;
+}
+
+test("happy path: /attention busy writes a thinking marker with ttl_ms and source pi", async () => {
+	const dir = freshDir("wez-happy-");
+	process.env.WEZTERM_PANE = "42";
+	const { cmdHandler, notes } = loadExt();
+	await cmdHandler("busy label here", { ui: { notify: (m, l) => notes.push({ msg: m, level: l }) } });
+	const m = JSON.parse(readFileSync(join(dir, "42"), "utf8"));
+	expect(m.type).toBe("thinking");
+	expect(m.source).toBe("pi");
+	expect(typeof m.ttl_ms).toBe("number");
+	expect(m.label).toBe("label here");
+	// The message reports the resolved state (busy -> thinking), pre-existing behavior.
+	expect(notes.at(-1)?.msg).toBe("Marked WezTerm pane as thinking");
+	rmSync(dir, { recursive: true, force: true });
+});
+
+test("F1: last requested mutation wins — notify then clear leaves NO marker", async () => {
+	const dir = freshDir("wez-order1-");
+	process.env.WEZTERM_PANE = "42";
+	const { eventHandler } = loadExt();
+	let present = 0;
+	for (let i = 0; i < 30; i++) {
+		eventHandler("notify");
+		eventHandler("clear");
+		await sleep(10);
+		if (existsSync(join(dir, "42"))) present++;
+	}
+	expect(present).toBe(0);
+	rmSync(dir, { recursive: true, force: true });
+});
+
+test("F1: ordering preserved — clear then notify leaves a notify marker", async () => {
+	const dir = freshDir("wez-order2-");
+	process.env.WEZTERM_PANE = "42";
+	const { eventHandler } = loadExt();
+	writeFileSync(join(dir, "42"), "{}");
+	eventHandler("clear");
+	eventHandler("notify");
+	await sleep(20);
+	expect(existsSync(join(dir, "42"))).toBe(true);
+	expect(JSON.parse(readFileSync(join(dir, "42"), "utf8")).type).toBe("notify");
+	rmSync(dir, { recursive: true, force: true });
+});
+
+test("F3: filesystem failure reports io-error, NOT 'not set', when the pane IS set", async () => {
+	const parent = mkdtempSync(join(tmpdir(), "wez-io-"));
+	const dir = join(parent, "markers");
+	mkdirSync(dir);
+	chmodSync(dir, 0o500); // no write
+	process.env.WEZTERM_ATTENTION_DIR = dir;
+	process.env.WEZTERM_PANE = "42";
+	const { cmdHandler, notes } = loadExt();
+	await cmdHandler("notify", { ui: { notify: (m, l) => notes.push({ msg: m, level: l }) } });
+	const msg = notes.at(-1)?.msg ?? "";
+	expect(msg).toContain("I/O error");
+	expect(msg).not.toContain("not set");
+	chmodSync(dir, 0o700);
+	rmSync(parent, { recursive: true, force: true });
+});
+
+test("F3: missing pane still reports 'not set' (unchanged truthful behavior)", async () => {
+	freshDir("wez-missing-");
+	delete process.env.WEZTERM_PANE;
+	const { cmdHandler, notes } = loadExt();
+	await cmdHandler("notify", { ui: { notify: (m, l) => notes.push({ msg: m, level: l }) } });
+	expect(notes.at(-1)?.msg).toBe("WEZTERM_PANE is not set; nothing written");
+});
+
+test("F4: traversal pane id writes NOTHING outside the marker dir and is rejected", async () => {
+	const parent = mkdtempSync(join(tmpdir(), "wez-trav1-"));
+	const dir = join(parent, "markerdir");
+	mkdirSync(dir);
+	const victim = join(parent, "victim.txt");
+	writeFileSync(victim, "IMPORTANT");
+	process.env.WEZTERM_ATTENTION_DIR = dir;
+	process.env.WEZTERM_PANE = "../victim.txt";
+	const { cmdHandler, notes } = loadExt();
+	await cmdHandler("busy", { ui: { notify: (m, l) => notes.push({ msg: m, level: l }) } });
+	expect(readFileSync(victim, "utf8")).toBe("IMPORTANT"); // untouched
+	expect(notes.at(-1)?.msg).toContain("not a valid pane id");
+	rmSync(parent, { recursive: true, force: true });
+});
+
+test("F4: /attention clear with a traversal pane id does NOT delete an outside file", async () => {
+	const parent = mkdtempSync(join(tmpdir(), "wez-trav2-"));
+	const dir = join(parent, "markerdir");
+	mkdirSync(dir);
+	const victim = join(parent, "victim.txt");
+	writeFileSync(victim, "IMPORTANT");
+	process.env.WEZTERM_ATTENTION_DIR = dir;
+	process.env.WEZTERM_PANE = "../victim.txt";
+	const { cmdHandler } = loadExt();
+	await cmdHandler("clear", { ui: { notify: () => {} } });
+	expect(existsSync(victim)).toBe(true); // not deleted
+	rmSync(parent, { recursive: true, force: true });
+});

--- a/tests/pi_extension.test.ts
+++ b/tests/pi_extension.test.ts
@@ -6,7 +6,11 @@
 //
 // The mock event bus models the real one (node:events under the hood): `on`
 // appends a handler and returns a disposer that removes it, and `emit` invokes
-// every current handler.
+// every current handler. One deliberate divergence: this `emit` awaits the
+// handlers, while the real bus discards their return value. That is a test
+// affordance, not a capability production has — do not conclude from these tests
+// that emitting is awaitable. Ordering is guaranteed by `mutationChain`, not by
+// awaiting the emit.
 //
 // Fidelity caveat: `loadExt().load()` re-invokes the default export against the
 // SAME module scope, so it exercises re-registration but NOT a cache-cleared
@@ -14,7 +18,7 @@
 // test below covers genuine module re-evaluation via `import(...?gen=N)`; that
 // one is what actually locks retire-at-registration against the WeakMap-scope
 // and key-choice regressions.
-import { test, expect } from "bun:test";
+import { test, expect, afterEach } from "bun:test";
 import { mkdtempSync, mkdirSync, existsSync, readFileSync, readdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -55,10 +59,35 @@ function loadExt() {
 	return { lifecycle, emit, load, handlers, channels, commandCount: () => commandCalls };
 }
 
-function freshDir(prefix: string): string {
+// Teardown is centralised so a FAILING assertion still cleans up, and so no test
+// inherits env from its neighbour. Previously both were done by trailing
+// statements, which a failed expect() skips — leaking temp dirs exactly when you
+// are iterating on a red test, and leaving WEZTERM_PANE set to a traversal path
+// after the traversal tests.
+const tempDirs: string[] = [];
+afterEach(() => {
+	for (const d of tempDirs.splice(0)) rmSync(d, { recursive: true, force: true });
+	delete process.env.WEZTERM_PANE;
+	delete process.env.WEZTERM_ATTENTION_DIR;
+	delete process.env.PI_WEZTERM_ATTENTION_TTL_MS;
+});
+
+// A temp dir registered for automatic teardown.
+function tempDir(prefix: string): string {
 	const d = mkdtempSync(join(tmpdir(), prefix));
+	tempDirs.push(d);
+	return d;
+}
+
+// ...and pointed at by WEZTERM_ATTENTION_DIR.
+function freshDir(prefix: string): string {
+	const d = tempDir(prefix);
 	process.env.WEZTERM_ATTENTION_DIR = d;
 	return d;
+}
+
+function readMarker(dir: string, pane = "42"): Record<string, unknown> {
+	return JSON.parse(readFileSync(join(dir, pane), "utf8"));
 }
 
 test("lifecycle: agent_start writes a thinking marker with ttl_ms, updated_at, source pi", async () => {
@@ -66,12 +95,11 @@ test("lifecycle: agent_start writes a thinking marker with ttl_ms, updated_at, s
 	process.env.WEZTERM_PANE = "42";
 	const { lifecycle } = loadExt();
 	await lifecycle["agent_start"]!();
-	const m = JSON.parse(readFileSync(join(dir, "42"), "utf8"));
+	const m = readMarker(dir);
 	expect(m.type).toBe("thinking");
 	expect(m.source).toBe("pi");
 	expect(typeof m.ttl_ms).toBe("number");
 	expect(typeof m.updated_at).toBe("number"); // locks the contract field bun won't typecheck
-	rmSync(dir, { recursive: true, force: true });
 });
 
 test("lifecycle: tool_execution_start writes a thinking marker", async () => {
@@ -79,8 +107,7 @@ test("lifecycle: tool_execution_start writes a thinking marker", async () => {
 	process.env.WEZTERM_PANE = "42";
 	const { lifecycle } = loadExt();
 	await lifecycle["tool_execution_start"]!();
-	expect(JSON.parse(readFileSync(join(dir, "42"), "utf8")).type).toBe("thinking");
-	rmSync(dir, { recursive: true, force: true });
+	expect(readMarker(dir).type).toBe("thinking");
 });
 
 test("lifecycle: agent_settled — not agent_end — writes the stop marker", async () => {
@@ -92,10 +119,9 @@ test("lifecycle: agent_settled — not agent_end — writes the stop marker", as
 	const { lifecycle } = loadExt();
 	expect(lifecycle["agent_end"]).toBeUndefined();
 	await lifecycle["agent_settled"]!();
-	const m = JSON.parse(readFileSync(join(dir, "42"), "utf8"));
+	const m = readMarker(dir);
 	expect(m.type).toBe("stop");
 	expect(m.ttl_ms).toBeUndefined();
-	rmSync(dir, { recursive: true, force: true });
 });
 
 test("registration: the extension listens on the wezterm-attention:mark channel", () => {
@@ -115,10 +141,9 @@ test("event: emitting a notify object writes a labeled notify marker", async () 
 	process.env.WEZTERM_PANE = "42";
 	const { emit } = loadExt();
 	await emit({ type: "notify", label: "answer me" });
-	const m = JSON.parse(readFileSync(join(dir, "42"), "utf8"));
+	const m = readMarker(dir);
 	expect(m.type).toBe("notify");
 	expect(m.label).toBe("answer me");
-	rmSync(dir, { recursive: true, force: true });
 });
 
 test("event: a bare string state is accepted", async () => {
@@ -126,8 +151,7 @@ test("event: a bare string state is accepted", async () => {
 	process.env.WEZTERM_PANE = "42";
 	const { emit } = loadExt();
 	await emit("review");
-	expect(JSON.parse(readFileSync(join(dir, "42"), "utf8")).type).toBe("review");
-	rmSync(dir, { recursive: true, force: true });
+	expect(readMarker(dir).type).toBe("review");
 });
 
 test("ordering: notify then clear leaves NO marker (last requested wins)", async () => {
@@ -144,7 +168,6 @@ test("ordering: notify then clear leaves NO marker (last requested wins)", async
 		if (existsSync(join(dir, "42"))) present++;
 	}
 	expect(present).toBe(0);
-	rmSync(dir, { recursive: true, force: true });
 });
 
 test("ordering: clear then notify leaves a notify marker", async () => {
@@ -156,8 +179,7 @@ test("ordering: clear then notify leaves a notify marker", async () => {
 	const b = emit("notify");
 	await Promise.all([a, b]);
 	expect(existsSync(join(dir, "42"))).toBe(true);
-	expect(JSON.parse(readFileSync(join(dir, "42"), "utf8")).type).toBe("notify");
-	rmSync(dir, { recursive: true, force: true });
+	expect(readMarker(dir).type).toBe("notify");
 });
 
 test("reload (real module re-eval): retire-at-registration collapses N fresh generations to one listener", async () => {
@@ -191,23 +213,29 @@ test("reload (real module re-eval): retire-at-registration collapses N fresh gen
 		mod.default(makePi() as any);
 	}
 	expect(handlers.length).toBe(1); // all four generations collapsed to one live listener
-	expect(handlers.map((e) => e.gen)).toEqual([3]); // and the survivor is the NEWEST one
+	// The survivor is the NEWEST generation. This asserts listener IDENTITY because
+	// nothing else distinguishes the generations: they are byte-identical modules and
+	// every config value is re-read from process.env at write time.
+	//
+	// That makes it design-specific on purpose. Under the deferred bus-owned-controller
+	// design — one listener installed once per bus, later generations swapping only a
+	// delegate — the survivor would legitimately be gen 0 and this line SHOULD fail.
+	// If you are doing that migration, revisit this expectation; do not "fix" the
+	// controller to preserve gen-3 identity, which would reintroduce the register/
+	// retire dance the migration exists to delete.
+	expect(handlers.map((e) => e.gen)).toEqual([3]);
 });
 
 test("reload: a new generation retires the previous listener (no accumulation)", async () => {
 	// Same-instance re-registration (see the fidelity caveat at the top): covers
 	// the re-register path; the real-module-re-eval test above covers cross-gen.
-	const dir = freshDir("wez-reload-");
-	process.env.WEZTERM_PANE = "42";
+	freshDir("wez-reload-");
 	const h = loadExt();
 	expect(h.handlers.length).toBe(1); // gen-0 registered exactly one listener
 	h.load(); // gen-1 registers and retires gen-0's listener
 	expect(h.handlers.length).toBe(1); // one, not stacked
 	h.load(); // gen-2
 	expect(h.handlers.length).toBe(1);
-	await Promise.all([h.emit("notify"), h.emit("clear")]);
-	expect(existsSync(join(dir, "42"))).toBe(false);
-	rmSync(dir, { recursive: true, force: true });
 });
 
 test("failed reload: session_shutdown does NOT dispose the listener", async () => {
@@ -223,7 +251,6 @@ test("failed reload: session_shutdown does NOT dispose the listener", async () =
 	expect(h.handlers.length).toBe(1); // listener still live
 	await h.emit("notify"); // cooperative path still works
 	expect(existsSync(join(dir, "42"))).toBe(true);
-	rmSync(dir, { recursive: true, force: true });
 });
 
 test("session_shutdown drains in-flight writes before returning", async () => {
@@ -236,11 +263,10 @@ test("session_shutdown drains in-flight writes before returning", async () => {
 	await h.lifecycle["session_shutdown"]!(); // must not return until `pending` settles
 	expect(existsSync(join(dir, "42"))).toBe(true); // drained → write landed
 	await pending;
-	rmSync(dir, { recursive: true, force: true });
 });
 
 test("traversal: a bad pane id writes NOTHING outside the marker dir", async () => {
-	const parent = mkdtempSync(join(tmpdir(), "wez-trav1-"));
+	const parent = tempDir("wez-trav1-");
 	const dir = join(parent, "markerdir");
 	mkdirSync(dir);
 	const victim = join(parent, "victim.txt");
@@ -250,11 +276,10 @@ test("traversal: a bad pane id writes NOTHING outside the marker dir", async () 
 	const { emit } = loadExt();
 	await emit("notify");
 	expect(readFileSync(victim, "utf8")).toBe("IMPORTANT"); // untouched
-	rmSync(parent, { recursive: true, force: true });
 });
 
 test("traversal: a bad pane id does NOT delete an outside file on clear", async () => {
-	const parent = mkdtempSync(join(tmpdir(), "wez-trav2-"));
+	const parent = tempDir("wez-trav2-");
 	const dir = join(parent, "markerdir");
 	mkdirSync(dir);
 	const victim = join(parent, "victim.txt");
@@ -264,7 +289,6 @@ test("traversal: a bad pane id does NOT delete an outside file on clear", async 
 	const { emit } = loadExt();
 	await emit("clear");
 	expect(existsSync(victim)).toBe(true); // not deleted
-	rmSync(parent, { recursive: true, force: true });
 });
 
 test("cleanup: a failed rename does not leak temp files", async () => {
@@ -275,16 +299,14 @@ test("cleanup: a failed rename does not leak temp files", async () => {
 	for (let i = 0; i < 10; i++) await emit("notify");
 	const leaked = readdirSync(dir).filter((f) => f.includes(".tmp."));
 	expect(leaked.length).toBe(0);
-	rmSync(dir, { recursive: true, force: true });
 });
 
 test("missing pane: lifecycle write is a silent no-op that creates no file", async () => {
 	const dir = freshDir("wez-nopane-");
-	delete process.env.WEZTERM_PANE;
+	delete process.env.WEZTERM_PANE; // the condition under test, not teardown
 	const { lifecycle } = loadExt();
 	await lifecycle["agent_start"]!();
 	expect(readdirSync(dir).length).toBe(0); // nothing written at all, not merely no "undefined" file
-	rmSync(dir, { recursive: true, force: true });
 });
 
 test('env: a unit-suffixed TTL ("30m") is rejected, not parsed as 30', async () => {
@@ -295,10 +317,8 @@ test('env: a unit-suffixed TTL ("30m") is rejected, not parsed as 30', async () 
 	process.env.PI_WEZTERM_ATTENTION_TTL_MS = "30m";
 	const { lifecycle } = loadExt();
 	await lifecycle["agent_start"]!();
-	const m = JSON.parse(readFileSync(join(dir, "42"), "utf8"));
+	const m = readMarker(dir);
 	expect(m.ttl_ms).toBe(30 * 60 * 1000); // default, NOT 30
-	delete process.env.PI_WEZTERM_ATTENTION_TTL_MS;
-	rmSync(dir, { recursive: true, force: true });
 });
 
 test("env: a relative WEZTERM_ATTENTION_DIR is rejected (no cwd scatter, no cwd delete)", async () => {
@@ -314,7 +334,6 @@ test("env: a relative WEZTERM_ATTENTION_DIR is rejected (no cwd scatter, no cwd 
 	expect(existsSync(join(relDir, "42"))).toBe(false);
 	expect(existsSync(relDir)).toBe(false); // dir never even created
 	rmSync(relDir, { recursive: true, force: true });
-	delete process.env.WEZTERM_ATTENTION_DIR;
 });
 
 test('env: TTL_MS="0" falls back to the default, not an instantly-stale marker', async () => {
@@ -326,10 +345,8 @@ test('env: TTL_MS="0" falls back to the default, not an instantly-stale marker',
 	process.env.PI_WEZTERM_ATTENTION_TTL_MS = "0";
 	const { lifecycle } = loadExt();
 	await lifecycle["agent_start"]!();
-	const m = JSON.parse(readFileSync(join(dir, "42"), "utf8"));
+	const m = readMarker(dir);
 	expect(m.ttl_ms).toBe(30 * 60 * 1000); // default, NOT 0
-	delete process.env.PI_WEZTERM_ATTENTION_TTL_MS;
-	rmSync(dir, { recursive: true, force: true });
 });
 
 // The alias table README.md advertises to other extension authors. It is a public
@@ -353,7 +370,7 @@ test("event: every documented alias maps to its canonical marker state", async (
 		process.env.WEZTERM_PANE = "42";
 		const h = loadExt();
 		await h.emit(alias);
-		const m = JSON.parse(readFileSync(join(dir, "42"), "utf8"));
+		const m = readMarker(dir);
 		expect(m.type).toBe(expected); // `${alias}` → `${expected}`
 		rmSync(dir, { recursive: true, force: true });
 	}
@@ -368,5 +385,4 @@ test("event: an unrecognized state is rejected, writing nothing", async () => {
 	const h = loadExt();
 	await h.emit("bogus");
 	expect(readdirSync(dir).length).toBe(0);
-	rmSync(dir, { recursive: true, force: true });
 });


### PR DESCRIPTION
## Summary

Vendors the Pi→WezTerm attention writer into this repo as a first-class, installable package (`pi install git:github.com/pro-vi/wezterm-attention`), so the marker *writer* lives beside the marker *contract* it depends on. Previously it was a private, unpublished dir on one machine — the split that once shipped `ttl_ms` from the extension before the plugin read it. Also corrects the README's Codex section, which documented an approach that's since broken.

## Scope

The extension wires **Pi's lifecycle to WezTerm tab state, automatically** — no commands, no configuration:

- `agent_start` / `tool_execution_start` → `thinking` (violet spinner)
- `agent_settled` → `stop` (mint ✓) — *not* `agent_end`, which fires at the end of every low-level run and can be followed by auto-retry, auto-compaction, or queued follow-ups (a false mid-task ✓). Requires Pi 0.80.5+.

It also listens on a shared event bus so **other Pi extensions can request a state** — notably `notify` (the rose `!` "waiting for you"), which the lifecycle events never produce. An ask-user extension emits `pi.events.emit("wezterm-attention:mark", { type: "notify" })` while it waits, `{ type: "clear" }` when done. That's the whole surface.

## Key Changes

- **`pi/index.ts`** — the Pi extension: three lifecycle hooks + the `wezterm-attention:mark` listener. Imports `@earendil-works/pi-coding-agent` (Pi's current scope). Marker core is hardened (see Review below): serial mutation queue (ordering), numeric pane-id validation, temp-file cleanup on failed rename.
- **`package.json`** (new, repo root) — `pi.extensions` manifest pointing at `./pi/index.ts`, so the one-command git install resolves. The peer dep is marked **optional** on purpose (see below). Adds a `bun test` script.
- **`tests/pi_extension.test.ts`** — 23 regression tests over the lifecycle + event surface, run via `npm test`. Every fix-locking test is mutation-verified: reverting the fix it guards turns it red.
- **README** — a Pi section (install, automatic behavior, the `wezterm-attention:mark` event, env overrides); and a corrected Codex section (the old `~/.codex/config.toml` top-level `notify` recipe is finish-only and silently clobbered by the desktop "Computer Use" app — replaced with lifecycle hooks + the `/hooks` trust step, plus an explicit coverage caveat).

## Technical Context

**Why here, not pi-rov or `examples/`.** This repo owns the marker contract; the Claude/Codex writers already live here. The Pi writer was the one *orphan* (no owning project), so it's vendored here — co-locating writer and reader makes contract changes atomic. Rejected: pi-rov ownership (fails its "independent extensions" bar), and `examples/` placement (those are paste fragments; this is genuinely installable).

**The peer dep is marked *optional* on purpose.** The git-install path runs plain `npm install --omit=dev`, which does **not** suppress peers (that suppression is only on Pi's separate managed-npm path). A bare `peerDependencies:"*"` would make every install pull the whole Pi API tree, or fail. `peerDependenciesMeta.optional` stops that — verified empirically (install produces no `node_modules`). The import is `import type` anyway (erased at runtime) and Pi's loader aliases the package to its bundled copy.

**Codex `notify` coverage.** The README's Codex section notes that `PermissionRequest` fires only for command/patch/network approvals, not for `request_user_input` / `request_permissions` / MCP elicitation. (Bootstrap has since taught its own Codex writer to cover the first two via `PreToolUse` tool-name detection; MCP elicitation has no tool-call hook and stays uncovered.)

## Review

Five rounds of adversarial review plus an external review, every finding confirmed against the code before fixing and re-priced by reachability; all closed. Highlights, all with regression tests and independent re-review of the concurrency-touching fixes:

- **Ordering** — the event bus fired mutations fire-and-forget, so `notify`→`clear` raced (marker left present, 50/50). Fixed with a serial mutation queue (emit order == apply order).
- **Path traversal** — an unvalidated `WEZTERM_PANE` (`../victim`) escaped the marker dir and `clear`'s `rm` could delete an outside file. Fixed with a numeric pane-id contract (`/^\d+$/`).
- **Temp-file leak** — a failed `rename` left the tmp file behind (20 events → 20 files). Fixed with cleanup in the catch (20 → 0).
- **Test determinism** — fixed-sleep tests could false-pass; now the handler returns its queue promise and tests await it (deterministic, ~20× faster).

## Testing

Verified end-to-end against the real Pi runtime (v0.80.10), in an isolated `PI_CODING_AGENT_DIR` so the still-active local copy couldn't answer for the vendored one:

- [x] `pi install git:…@<head>` — real clone + `npm install --omit=dev` installs nothing (optional peer skipped); `pi list` resolves from the git clone, not `~/.pi/agent`
- [x] pi's jiti loader loads `pi/index.ts` (type-only import erased, no error) and, on a turn, writes a correct marker (`thinking` with `ttl_ms` + `source:"pi"`)
- [x] event path: emitting `notify` writes a `notify` marker; `notify`→`clear` leaves none (ordering); a traversal pane id writes/deletes nothing outside the dir
- [x] `npm test` — 23/23 green, deterministic
- [x] **Reviewer live check** — VERIFIED (real WezTerm pane: violet thinking → mint ✓ stop, lights up correctly).  Original: (visual, can't be done headlessly): in a real WezTerm pane, drive a short Pi turn and watch the tab go violet (`thinking`) → mint ✓ (`stop`). If you run an ask-user-style extension that emits `wezterm-attention:mark`, confirm it flags rose `!`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Review rounds 4–5 (post-description)

The description above predates several rounds. What changed since:

- **`agent_settled` replaces `agent_end`.** `agent_end` is not terminal — Pi computes a `willRetry` hint for it internally, and the extension-facing event does not carry that flag, so an extension on `agent_end` provably cannot tell "done" from "about to retry". `agent_settled` fires only once Pi will not continue automatically.
- **Reload teardown, rearchitected.** Pi's shared event bus is never cleared, so a reloaded generation would leak a listener. Disposal happens when the *next* generation registers (register-first, so a throw leaks rather than silences), not on `session_shutdown` — a caught reload failure keeps the old generation running, and disposing there would silence it with no successor.
- **Marker I/O is off the agent's critical path.** Pi awaits lifecycle handlers from the agent loop down, with no timeout. Awaiting a marker write there put the filesystem inside the agent's latency budget and, on a mount whose syscalls block indefinitely, wedged the host — including `pi -p` never terminating. The three lifecycle handlers no longer await; the `session_shutdown` drain guarantees the writes land.
- **Degenerate-env hardening.** `WEZTERM_ATTENTION_DIR=""` or `HOME=""` previously resolved markers against the process cwd (writing there, and `rm`-ing there on clear). Resolution now requires an absolute path or no-ops.

### Known, accepted, documented in-code

The `session_shutdown` drain is capped at 2s so a hung filesystem cannot wedge Pi's reload or quit. Timing out does not *cancel* the abandoned write, so it can land after the next generation's and leave one stale tab tint until the next event or the marker's TTL. Priced P3: self-healing on the next tool call, and it needs the same blocking-mount precondition under which the critical-path fix above matters far more. Three plausible fixes (sticky abandoned flag, sharing the chain across generations, per-operation generation counter) were each implemented and measured, and each is worse than the defect. In particular, now that lifecycle writes are fire-and-forget, a shared cross-generation chain no longer risks host liveness — but it blocks every later generation's marker behind a stuck predecessor write, an unbounded cross-generation staleness strictly worse than the current per-generation isolation. The full reasoning is recorded at the handler so it is not re-proposed. Closing it properly needs a bus-owned controller, deferred.


