### PR TITLE
fix: refresh inactive tabs when attention changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ attention.apply_to_config(config, {
   -- Auto-clear these types when focusing their pane
   auto_clear = { "stop", "notify" },
 
+  -- Refresh custom tab titles when visible attention state changes
+  refresh_tab_bar = true,
+
   -- Stale marker cleanup by type, in milliseconds.
   -- Prevents zombie busy tabs if a process exits without clearing.
   -- Set to false to disable the config-driven sweep. Note: markers that carry
@@ -180,10 +183,14 @@ attention.apply_to_config(config, { auto_poll = false })
 
 -- Then in your existing update-status handler:
 wezterm.on('update-status', function(window, pane)
-  attention.poll(window)  -- reads markers, updates cache
-  -- ... your git status bar, battery, etc.
+  attention.poll(window)  -- reads markers, updates cache, refreshes changed tabs
+  -- Set your left/right status after poll() so your text remains authoritative.
 end)
 ```
+
+The refresh uses alternating zero-width left-status values because stable WezTerm
+has no direct tab-bar invalidation method. Set `refresh_tab_bar = false` if your
+status handler must run before `attention.poll()`.
 
 ## Public API
 
@@ -329,8 +336,6 @@ if (process.env.WEZTERM_PANE && /^\d+$/.test(process.env.WEZTERM_PANE)) {
 }
 ```
 
-> **Tip:** Add `` execSync(`wezterm cli set-window-title --pane-id ${process.env.WEZTERM_PANE} " "`) `` after writing a marker to force an immediate tab redraw instead of waiting for the next poll cycle.
-
 ## Codex hooks
 
 Wire Codex through its **lifecycle hooks** (`~/.codex/hooks.json`). Avoid the older top-level
@@ -403,7 +408,7 @@ it isn't wired here yet.
 
 The plugin uses a **poller/renderer split** to avoid blocking WezTerm's GUI thread:
 
-1. **Poller** (`update-status` event) — runs on WezTerm's `config.status_update_interval` (default 1000ms). Reads marker files from disk and updates an in-memory cache.
+1. **Poller** (`update-status` event) — runs on WezTerm's `config.status_update_interval` (default 1000ms). Reads marker files, updates an in-memory cache, and refreshes the tab bar when visible attention state changes.
 2. **Renderer** (`format-tab-title` event) — fires on every tab repaint (mouse hover, key press, redraws). Reads only from the cache — zero I/O, instant returns.
 
 No background threads, no FFI, no external dependencies — just filesystem reads in Lua on a configurable interval.

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -37,6 +37,9 @@ local defaults = {
   -- These types auto-clear when their pane becomes active
   auto_clear = { "stop", "notify" },
 
+  -- Refresh custom tab titles when visible attention state changes
+  refresh_tab_bar = true,
+
   -- Stale marker cleanup by type, in milliseconds. Prevents zombie busy tabs
   -- after a process exits without clearing its marker. Set to false to disable.
   stale_after_ms = { thinking = 30 * 60 * 1000 },
@@ -109,6 +112,7 @@ end
 -- read only when acknowledging a cached terminal marker.
 
 local attention_cache = {} -- { [pane_id_string] = { type = "stop", frame = 0 } }
+local redraw_nonce = {}
 
 -- ── Internal helpers ────────────────────────────────────────────────────────
 
@@ -250,16 +254,17 @@ function M.poll(window, opts)
   local now = now_ms()
   local animation_frame = M._poll_animation_frame or 0
   M._poll_animation_frame = (animation_frame + 1) % 4
+  local redraw_needed = false
 
   for _, tab in ipairs(mux_win:tabs()) do
     for _, p in ipairs(tab:panes()) do
       local id = tostring(p:pane_id())
+      local previous = attention_cache[id]
       local atype, frame, updated_at, marker_ttl_ms, raw = read_marker(dir, id)
       if atype then
-        local cached = attention_cache[id]
         local observed_at = now
-        if cached and cached.raw == raw and cached.observed_at then
-          observed_at = cached.observed_at
+        if previous and previous.raw == raw and previous.observed_at then
+          observed_at = previous.observed_at
         end
 
         local effective_updated_at = updated_at or observed_at
@@ -283,7 +288,25 @@ function M.poll(window, opts)
       else
         attention_cache[id] = nil
       end
+
+      local current = attention_cache[id]
+      if (previous and previous.type) ~= (current and current.type)
+          or (previous and previous.frame) ~= (current and current.frame) then
+        redraw_needed = true
+      end
     end
+  end
+
+  local refresh_tab_bar = M._active_refresh_tab_bar
+  if opts and opts.refresh_tab_bar ~= nil then
+    refresh_tab_bar = opts.refresh_tab_bar
+  end
+  if redraw_needed and refresh_tab_bar ~= false then
+    local window_id = tostring(window:window_id())
+    redraw_nonce[window_id] = not redraw_nonce[window_id]
+    -- Alternating zero-width status text is the stable WezTerm API that
+    -- schedules custom tab-title recomputation without visible output.
+    window:set_left_status(utf8.char(redraw_nonce[window_id] and 0x200b or 0x200c))
   end
 end
 
@@ -369,6 +392,7 @@ function M.apply_to_config(config, opts)
   local stale_after_ms = opts.stale_after_ms
   if stale_after_ms == nil then stale_after_ms = defaults.stale_after_ms end
   M._active_stale_after_ms = stale_after_ms
+  M._active_refresh_tab_bar = opts.refresh_tab_bar ~= false
 
   -- Build lookup tables
   local clear_set = {}

--- a/tests/auto_clear_spec.lua
+++ b/tests/auto_clear_spec.lua
@@ -10,6 +10,7 @@ os.remove(test_dir)
 assert(os.execute("mkdir -p " .. shell_quote(test_dir)) == 0)
 
 local handlers = {}
+local status_updates = {}
 local wezterm = {
   home_dir = test_dir,
   action_callback = function(callback) return callback end,
@@ -70,7 +71,7 @@ local function gui_pane(pane_id)
   }
 end
 
-local function poll(pane_ids)
+local function poll(pane_ids, opts)
   local panes = {}
   for _, pane_id in ipairs(pane_ids) do
     table.insert(panes, mux_pane(pane_id))
@@ -84,9 +85,13 @@ local function poll(pane_ids)
   }
   local window = {
     mux_window = function() return mux_window end,
+    window_id = function() return 1 end,
+    set_left_status = function(_, status)
+      table.insert(status_updates, status)
+    end,
   }
 
-  attention.poll(window)
+  attention.poll(window, opts)
 end
 
 local function tab(active_pane_id, sibling_pane_id, is_active)
@@ -181,6 +186,42 @@ test("auto-clear never deletes a newer non-clearable marker", function()
 
   assert(marker_exists(501), "newer thinking marker should remain on disk")
   assert(attention.get_attention(501) == "thinking", "cache should adopt the newer marker")
+end)
+
+test("poll refreshes the tab bar only when visible attention changes", function()
+  status_updates = {}
+  write_marker(601, "notify")
+
+  poll({ 601 })
+  assert(#status_updates == 1, "new marker should request one refresh")
+
+  poll({ 601 })
+  assert(#status_updates == 1, "unchanged marker should not request another refresh")
+
+  os.remove(test_dir .. "/601")
+  poll({ 601 })
+  assert(#status_updates == 2, "removed marker should request another refresh")
+  assert(status_updates[1] ~= status_updates[2], "refresh nonce should alternate")
+end)
+
+test("poll refreshes each generated thinking frame", function()
+  status_updates = {}
+  write_marker(701, "thinking")
+
+  poll({ 701 })
+  poll({ 701 })
+
+  assert(#status_updates == 2, "thinking animation should refresh each frame")
+  assert(status_updates[1] ~= status_updates[2], "refresh nonce should alternate")
+end)
+
+test("poll can leave status ownership untouched", function()
+  status_updates = {}
+  write_marker(801, "notify")
+
+  poll({ 801 }, { refresh_tab_bar = false })
+
+  assert(#status_updates == 0, "disabled refresh should not touch left status")
 end)
 
 os.execute("rm -rf " .. shell_quote(test_dir))


### PR DESCRIPTION
## Problem

The poller updates `attention_cache`, but stable WezTerm does not rerun `format-tab-title` merely because an `update-status` handler changed Lua state. An inactive tab therefore keeps its stale title until another UI event, such as activating the tab, triggers a repaint.

## Fix

- Detect visible attention type/frame changes during `poll()`.
- Alternate two zero-width left-status values to request WezTerm's existing title/status recomputation path.
- Refresh once for static state changes and once per generated thinking frame.
- Add `refresh_tab_bar = false` for configurations that need exclusive status ownership.
- Remove the hook-side `set-window-title` workaround from the docs.

The nudge is invisible. Existing custom status handlers should set their status after `attention.poll()`, as shown in the updated manual-polling example.

## Tests

- 8 Lua poller/renderer tests pass, including add, unchanged, removal, animation, and opt-out coverage.
- 23 Pi extension tests pass.