### PR TITLE
fix: redraw inactive tabs without status writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Any process running inside WezTerm can write a marker. The contract is:
 1. **Write** a JSON file to `~/.local/state/wezterm-attention/<WEZTERM_PANE>`
 2. **Contents:** `{"type":"<state>"}` where state is `thinking`, `stop`, `notify`, or `review`
 3. **Optional:** `{"type":"thinking","frame":0}` — `frame` (0-3) controls the spinner position. If omitted for `thinking`, the plugin animates it during polling.
-4. **Recommended:** `revision` is a new non-empty string for every publication. It lets an identical `stop` or `notify` payload become visible again after the previous publication was acknowledged. Without it, the plugin uses the exact JSON bytes as the legacy identity.
+4. **Recommended:** `publication_id` is a new non-empty string for every publication. It lets an identical `stop` or `notify` payload become visible again after the previous publication was acknowledged. Without it, the plugin uses the exact JSON bytes as the legacy identity.
 5. **Optional:** `updated_at` or `updated_at_ms` records when the marker was refreshed. Seconds and milliseconds are both accepted.
 6. **Optional:** `ttl_ms` overrides stale cleanup for that marker. By default, stale `thinking` markers clear after 30 minutes.
 7. **Cleanup** is automatic — canonical markers are removed when panes close or stale TTL expires. Focusing a pane writes an acknowledgement sidecar instead of removing writer-owned state.
@@ -144,8 +144,8 @@ The `WEZTERM_PANE` environment variable is injected by WezTerm into every shell 
 case "$WEZTERM_PANE" in '' | *[!0-9]*) exit 0 ;; esac  # numeric pane id only
 MARKER_DIR="$HOME/.local/state/wezterm-attention"
 mkdir -p "$MARKER_DIR"
-if command -v uuidgen >/dev/null 2>&1; then REVISION="$(uuidgen)"; else REVISION="$(od -An -N16 -tx1 /dev/urandom | tr -d ' \n')"; fi
-printf '{"type":"stop","revision":"%s","updated_at":%s}\n' "$REVISION" "$(date +%s)" > "$MARKER_DIR/$WEZTERM_PANE.tmp" && mv "$MARKER_DIR/$WEZTERM_PANE.tmp" "$MARKER_DIR/$WEZTERM_PANE"
+if command -v uuidgen >/dev/null 2>&1; then PUBLICATION_ID="$(uuidgen)"; else PUBLICATION_ID="$(od -An -N16 -tx1 /dev/urandom | tr -d ' \n')"; fi
+printf '{"type":"stop","publication_id":"%s","updated_at":%s}\n' "$PUBLICATION_ID" "$(date +%s)" > "$MARKER_DIR/$WEZTERM_PANE.tmp" && mv "$MARKER_DIR/$WEZTERM_PANE.tmp" "$MARKER_DIR/$WEZTERM_PANE"
 ```
 
 ### TypeScript / Bun
@@ -162,7 +162,7 @@ const dir = join(process.env.HOME!, ".local", "state", "wezterm-attention");
 await mkdir(dir, { recursive: true });
 
 const file = join(dir, pane);
-await writeFile(file + ".tmp", JSON.stringify({ type: "stop", revision: randomUUID(), updated_at: Date.now() }));
+await writeFile(file + ".tmp", JSON.stringify({ type: "stop", publication_id: randomUUID(), updated_at: Date.now() }));
 await rename(file + ".tmp", file);
 ```
 
@@ -180,7 +180,7 @@ const dir = path.join(process.env.HOME, ".local", "state", "wezterm-attention");
 fs.mkdirSync(dir, { recursive: true });
 
 const file = path.join(dir, pane);
-fs.writeFileSync(file + ".tmp", JSON.stringify({ type: "stop", revision: randomUUID(), updated_at: Date.now() }));
+fs.writeFileSync(file + ".tmp", JSON.stringify({ type: "stop", publication_id: randomUUID(), updated_at: Date.now() }));
 fs.renameSync(file + ".tmp", file);
 ```
 
@@ -304,7 +304,7 @@ if (process.env.WEZTERM_PANE && /^\d+$/.test(process.env.WEZTERM_PANE)) {
   } catch {}
 
   mkdirSync(markerDir, { recursive: true });
-  writeFileSync(markerFile + '.tmp', JSON.stringify({ type: 'thinking', revision: randomUUID(), frame, updated_at: Date.now() }));
+  writeFileSync(markerFile + '.tmp', JSON.stringify({ type: 'thinking', publication_id: randomUUID(), frame, updated_at: Date.now() }));
   renameSync(markerFile + '.tmp', markerFile);
 }
 ```
@@ -317,7 +317,7 @@ if (process.env.WEZTERM_PANE && /^\d+$/.test(process.env.WEZTERM_PANE)) {
   const markerDir = `${process.env.HOME}/.local/state/wezterm-attention`;
   const markerFile = `${markerDir}/${process.env.WEZTERM_PANE}`;
   mkdirSync(markerDir, { recursive: true });
-  writeFileSync(markerFile + '.tmp', JSON.stringify({ type: 'stop', revision: randomUUID(), updated_at: Date.now() }));
+  writeFileSync(markerFile + '.tmp', JSON.stringify({ type: 'stop', publication_id: randomUUID(), updated_at: Date.now() }));
   renameSync(markerFile + '.tmp', markerFile);
 }
 ```
@@ -330,7 +330,7 @@ if (process.env.WEZTERM_PANE && /^\d+$/.test(process.env.WEZTERM_PANE)) {
   const markerDir = `${process.env.HOME}/.local/state/wezterm-attention`;
   const markerFile = `${markerDir}/${process.env.WEZTERM_PANE}`;
   mkdirSync(markerDir, { recursive: true });
-  writeFileSync(markerFile + '.tmp', JSON.stringify({ type: 'notify', revision: randomUUID(), updated_at: Date.now() }));
+  writeFileSync(markerFile + '.tmp', JSON.stringify({ type: 'notify', publication_id: randomUUID(), updated_at: Date.now() }));
   renameSync(markerFile + '.tmp', markerFile);
 }
 ```
@@ -386,7 +386,7 @@ async function writeWezTermMarker(marker: Record<string, unknown>): Promise<void
   const dir = join(home, ".local", "state", "wezterm-attention");
   await mkdir(dir, { recursive: true });
   const file = join(dir, paneId);
-  await writeFile(file + ".tmp", JSON.stringify({ source: "codex", updated_at_ms: Date.now(), ...marker, revision: randomUUID() }));
+  await writeFile(file + ".tmp", JSON.stringify({ source: "codex", updated_at_ms: Date.now(), ...marker, publication_id: randomUUID() }));
   await rename(file + ".tmp", file); // atomic
 }
 // PreToolUse:        writeWezTermMarker({ type: "thinking" })

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ A WezTerm plugin that turns your tab bar into a notification system. Any CLI too
 | `notify` | ! | Rose | Something needs your attention |
 | `review` | ◆ | Gold | Manually flagged for review |
 
-Tabs light up when a background process writes a marker—even when another pane in that tab is currently focused. Focusing a pane auto-clears only that pane's `stop` and `notify`; markers from unfocused sibling panes remain visible until you visit them. `thinking` and `review` persist until explicitly removed.
+Tabs light up when a background process writes a marker—even when another pane in that tab is currently focused, and even when the tab itself is not the one you are on. Focusing a pane acknowledges only that pane's `stop` and `notify`; markers from unfocused sibling panes remain visible until you visit them. `thinking` persists until its writer removes it or its TTL expires; `review` persists until explicitly removed.
+
+Only the active pane of the focused window is acknowledged. The writer-owned marker stays in place; the plugin records the exact displayed identity in a `.ack` sidecar, so unseen notifications remain visible.
 
 When multiple panes in a tab have different states, the highest-priority one wins: **notify > stop > review > thinking**.
 
@@ -26,7 +28,7 @@ attention.apply_to_config(config)
 
 By default, the plugin owns tab title formatting (`dir / title` + attention indicators). It also registers pane cleanup, a marker poller, and an `Alt+B` keybind to toggle review mode. `Alt+B` operates on the whole active tab: it flags the active pane, and clears the flag from every pane in the tab when any are already flagged (so split tabs can always be cleared with one press). It keys off whether `review` is set anywhere in the tab, independent of which indicator is currently rendered — a higher-priority `stop`/`notify` can mask the ◆.
 
-> **Important:** WezTerm only runs the **first** registered `format-tab-title` handler. If another plugin (e.g. tabline.wez) registers one before this plugin, all attention features — indicators, colors, and auto-clear — are disabled. Make sure `apply_to_config` runs before any other plugin that touches tab titles, or use `renderer = "manual"` to integrate via the API instead.
+> **Important:** WezTerm only runs the **first** registered `format-tab-title` handler. If another plugin (e.g. tabline.wez) registers one first, this plugin still polls and acknowledges markers, but its indicators and colors are not rendered. Make sure `apply_to_config` runs first, or use `renderer = "manual"` to integrate via the API instead.
 
 ## Render modes
 
@@ -97,7 +99,14 @@ attention.apply_to_config(config, {
   -- Priority order (last = highest)
   priority = { "thinking", "review", "stop", "notify" },
 
-  -- Auto-clear these types when focusing their pane
+  -- Wall-clock bucket used for generated thinking frames. A coarse WezTerm
+  -- clock clamps this to its actual resolution.
+  frame_interval_ms = 1000,
+
+  -- Per-window safety cap for poll-triggered compatibility redraws.
+  max_redraws_per_second = 4,
+
+  -- Visually acknowledge these types when focusing their pane
   auto_clear = { "stop", "notify" },
 
   -- Stale marker cleanup by type, in milliseconds.
@@ -120,9 +129,10 @@ Any process running inside WezTerm can write a marker. The contract is:
 1. **Write** a JSON file to `~/.local/state/wezterm-attention/<WEZTERM_PANE>`
 2. **Contents:** `{"type":"<state>"}` where state is `thinking`, `stop`, `notify`, or `review`
 3. **Optional:** `{"type":"thinking","frame":0}` — `frame` (0-3) controls the spinner position. If omitted for `thinking`, the plugin animates it during polling.
-4. **Optional:** `updated_at` or `updated_at_ms` records when the marker was refreshed. Seconds and milliseconds are both accepted.
-5. **Optional:** `ttl_ms` overrides stale cleanup for that marker. By default, stale `thinking` markers clear after 30 minutes.
-6. **Cleanup** is automatic — markers are removed when panes close, their panes become focused, or stale TTL expires
+4. **Recommended:** `revision` is a new non-empty string for every publication. It lets an identical `stop` or `notify` payload become visible again after the previous publication was acknowledged. Without it, the plugin uses the exact JSON bytes as the legacy identity.
+5. **Optional:** `updated_at` or `updated_at_ms` records when the marker was refreshed. Seconds and milliseconds are both accepted.
+6. **Optional:** `ttl_ms` overrides stale cleanup for that marker. By default, stale `thinking` markers clear after 30 minutes.
+7. **Cleanup** is automatic — canonical markers are removed when panes close or stale TTL expires. Focusing a pane writes an acknowledgement sidecar instead of removing writer-owned state.
 
 The `WEZTERM_PANE` environment variable is injected by WezTerm into every shell it spawns. That's the pane's unique ID — always a non-negative integer. Validate it (`/^\d+$/`) before building a path from it: a stray `../…` value would otherwise write to, or delete, a file outside the marker directory. Every example and fragment below enforces this.
 
@@ -134,13 +144,15 @@ The `WEZTERM_PANE` environment variable is injected by WezTerm into every shell 
 case "$WEZTERM_PANE" in '' | *[!0-9]*) exit 0 ;; esac  # numeric pane id only
 MARKER_DIR="$HOME/.local/state/wezterm-attention"
 mkdir -p "$MARKER_DIR"
-printf '{"type":"stop","updated_at":%s}\n' "$(date +%s)" > "$MARKER_DIR/$WEZTERM_PANE.tmp" && mv "$MARKER_DIR/$WEZTERM_PANE.tmp" "$MARKER_DIR/$WEZTERM_PANE"
+if command -v uuidgen >/dev/null 2>&1; then REVISION="$(uuidgen)"; else REVISION="$(od -An -N16 -tx1 /dev/urandom | tr -d ' \n')"; fi
+printf '{"type":"stop","revision":"%s","updated_at":%s}\n' "$REVISION" "$(date +%s)" > "$MARKER_DIR/$WEZTERM_PANE.tmp" && mv "$MARKER_DIR/$WEZTERM_PANE.tmp" "$MARKER_DIR/$WEZTERM_PANE"
 ```
 
 ### TypeScript / Bun
 
 ```typescript
 import { mkdir, writeFile, rename } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
 import { join } from "node:path";
 
 const pane = process.env.WEZTERM_PANE;
@@ -150,7 +162,7 @@ const dir = join(process.env.HOME!, ".local", "state", "wezterm-attention");
 await mkdir(dir, { recursive: true });
 
 const file = join(dir, pane);
-await writeFile(file + ".tmp", JSON.stringify({ type: "stop", updated_at: Date.now() }));
+await writeFile(file + ".tmp", JSON.stringify({ type: "stop", revision: randomUUID(), updated_at: Date.now() }));
 await rename(file + ".tmp", file);
 ```
 
@@ -159,6 +171,7 @@ await rename(file + ".tmp", file);
 ```javascript
 const fs = require("fs");
 const path = require("path");
+const { randomUUID } = require("crypto");
 
 const pane = process.env.WEZTERM_PANE;
 if (!pane || !/^\d+$/.test(pane)) process.exit(0); // numeric pane id only
@@ -167,7 +180,7 @@ const dir = path.join(process.env.HOME, ".local", "state", "wezterm-attention");
 fs.mkdirSync(dir, { recursive: true });
 
 const file = path.join(dir, pane);
-fs.writeFileSync(file + ".tmp", JSON.stringify({ type: "stop", updated_at: Date.now() }));
+fs.writeFileSync(file + ".tmp", JSON.stringify({ type: "stop", revision: randomUUID(), updated_at: Date.now() }));
 fs.renameSync(file + ".tmp", file);
 ```
 
@@ -180,7 +193,7 @@ attention.apply_to_config(config, { auto_poll = false })
 
 -- Then in your existing update-status handler:
 wezterm.on('update-status', function(window, pane)
-  attention.poll(window)  -- reads markers, updates cache
+  attention.poll(window, { active_pane = pane })  -- compatibility transport for older WezTerm builds
   -- ... your git status bar, battery, etc.
 end)
 ```
@@ -199,7 +212,7 @@ local state, frame = attention.get_attention(pane:pane_id())
 attention.remove_marker(pane:pane_id())
 
 -- Poll markers manually (for auto_poll = false)
-attention.poll(window)
+attention.poll(window, { active_pane = pane })
 
 -- Wrap a title function with attention decoration (for renderer = "manual")
 wezterm.on("format-tab-title", attention.wrap_title_formatter(function(tab, ctx)
@@ -280,6 +293,7 @@ Register hooks in `~/.claude/settings.json`:
 ```typescript
 if (process.env.WEZTERM_PANE && /^\d+$/.test(process.env.WEZTERM_PANE)) {
   const { mkdirSync, writeFileSync, readFileSync, renameSync } = require('fs');
+  const { randomUUID } = require('crypto');
   const markerDir = `${process.env.HOME}/.local/state/wezterm-attention`;
   const markerFile = `${markerDir}/${process.env.WEZTERM_PANE}`;
 
@@ -290,7 +304,7 @@ if (process.env.WEZTERM_PANE && /^\d+$/.test(process.env.WEZTERM_PANE)) {
   } catch {}
 
   mkdirSync(markerDir, { recursive: true });
-  writeFileSync(markerFile + '.tmp', JSON.stringify({ type: 'thinking', frame, updated_at: Date.now() }));
+  writeFileSync(markerFile + '.tmp', JSON.stringify({ type: 'thinking', revision: randomUUID(), frame, updated_at: Date.now() }));
   renameSync(markerFile + '.tmp', markerFile);
 }
 ```
@@ -299,10 +313,11 @@ if (process.env.WEZTERM_PANE && /^\d+$/.test(process.env.WEZTERM_PANE)) {
 ```typescript
 if (process.env.WEZTERM_PANE && /^\d+$/.test(process.env.WEZTERM_PANE)) {
   const { mkdirSync, writeFileSync, renameSync } = require('fs');
+  const { randomUUID } = require('crypto');
   const markerDir = `${process.env.HOME}/.local/state/wezterm-attention`;
   const markerFile = `${markerDir}/${process.env.WEZTERM_PANE}`;
   mkdirSync(markerDir, { recursive: true });
-  writeFileSync(markerFile + '.tmp', JSON.stringify({ type: 'stop', updated_at: Date.now() }));
+  writeFileSync(markerFile + '.tmp', JSON.stringify({ type: 'stop', revision: randomUUID(), updated_at: Date.now() }));
   renameSync(markerFile + '.tmp', markerFile);
 }
 ```
@@ -311,10 +326,11 @@ if (process.env.WEZTERM_PANE && /^\d+$/.test(process.env.WEZTERM_PANE)) {
 ```typescript
 if (process.env.WEZTERM_PANE && /^\d+$/.test(process.env.WEZTERM_PANE)) {
   const { mkdirSync, writeFileSync, renameSync } = require('fs');
+  const { randomUUID } = require('crypto');
   const markerDir = `${process.env.HOME}/.local/state/wezterm-attention`;
   const markerFile = `${markerDir}/${process.env.WEZTERM_PANE}`;
   mkdirSync(markerDir, { recursive: true });
-  writeFileSync(markerFile + '.tmp', JSON.stringify({ type: 'notify', updated_at: Date.now() }));
+  writeFileSync(markerFile + '.tmp', JSON.stringify({ type: 'notify', revision: randomUUID(), updated_at: Date.now() }));
   renameSync(markerFile + '.tmp', markerFile);
 }
 ```
@@ -328,8 +344,6 @@ if (process.env.WEZTERM_PANE && /^\d+$/.test(process.env.WEZTERM_PANE)) {
   } catch {}
 }
 ```
-
-> **Tip:** Add `` execSync(`wezterm cli set-window-title --pane-id ${process.env.WEZTERM_PANE} " "`) `` after writing a marker to force an immediate tab redraw instead of waiting for the next poll cycle.
 
 ## Codex hooks
 
@@ -366,12 +380,13 @@ async function writeWezTermMarker(marker: Record<string, unknown>): Promise<void
   // `require` is undefined under Node in module mode (throws). `await import`
   // works under both Node ESM and bun.
   const { mkdir, writeFile, rename } = await import("node:fs/promises");
+  const { randomUUID } = await import("node:crypto");
   const { join } = await import("node:path");
 
   const dir = join(home, ".local", "state", "wezterm-attention");
   await mkdir(dir, { recursive: true });
   const file = join(dir, paneId);
-  await writeFile(file + ".tmp", JSON.stringify({ source: "codex", updated_at_ms: Date.now(), ...marker }));
+  await writeFile(file + ".tmp", JSON.stringify({ source: "codex", updated_at_ms: Date.now(), ...marker, revision: randomUUID() }));
   await rename(file + ".tmp", file); // atomic
 }
 // PreToolUse:        writeWezTermMarker({ type: "thinking" })
@@ -403,8 +418,12 @@ it isn't wired here yet.
 
 The plugin uses a **poller/renderer split** to avoid blocking WezTerm's GUI thread:
 
-1. **Poller** (`update-status` event) — runs on WezTerm's `config.status_update_interval` (default 1000ms). Reads marker files from disk and updates an in-memory cache.
-2. **Renderer** (`format-tab-title` event) — fires on every tab repaint (mouse hover, key press, redraws). Reads only from the cache — zero I/O, instant returns.
+1. **Poller** (`update-status` event) — runs on WezTerm's `config.status_update_interval` (default 1000ms). Reads marker files and acknowledgement sidecars, then updates an in-memory cache. It acknowledges the focused window's current active pane and asks WezTerm to rebuild the tab bar only when what the tab bar would show has changed.
+2. **Renderer** (`format-tab-title` event) — fires on every tab repaint (mouse hover, key press, redraws). Reads only from the cache — zero I/O, instant returns, and no writes of any kind.
+
+WezTerm rebuilds tab titles when something it knows about changes, and a marker file appearing on disk is not one of those things. When the poller sees a visible attention change, it performs `ActivateTabRelative(0)` on the focused window. That re-activates the already-selected tab and makes WezTerm recompute every tab title. The plugin does not write either status string, the window title, or any user title.
+
+The compatibility action can pass through WezTerm's normal tab-activation path, including terminal focus reporting. It therefore runs only when the window has keyboard focus and a valid active pane. The plugin compares only what the tab bar shows—indicator, type, and color—so a marker changing behind a higher-priority sibling costs nothing. Generated spinner frames come from wall-clock buckets, so polls induced by the action see the same frame and terminate. A per-window redraw budget is the final backstop. If an action fails, that window logs once and stops requesting compatibility redraws.
 
 No background threads, no FFI, no external dependencies — just filesystem reads in Lua on a configurable interval.
 
@@ -414,8 +433,13 @@ No background threads, no FFI, no external dependencies — just filesystem read
 - Check the directory exists: `ls ~/.local/state/wezterm-attention/` (or your configured `dir`)
 - Verify `WEZTERM_PANE` is set: `echo $WEZTERM_PANE` (should print a number inside WezTerm)
 - Check file contents: `cat ~/.local/state/wezterm-attention/$WEZTERM_PANE` (should be valid JSON)
+- A matching `$WEZTERM_PANE.ack` means that publication was already displayed. Removing the sidecar makes it visible again; sidecars are plugin-owned and safe to remove before rolling back to an older plugin version.
 - Ensure your hooks write to the same path as the plugin's `dir` setting
-- `status_update_interval` defaults to 1000ms; markers update on this interval
+- `status_update_interval` defaults to 1000ms; markers update on this interval. Lower it if indicators feel slow — the redraw request rides on the same tick.
+
+**Indicators appear only when you switch tabs?**
+- The redraw needs `window:is_focused()`, `window:active_pane()`, and `window:perform_action()`. On a build missing any of them the plugin logs once to the WezTerm error log and falls back to WezTerm's own redraw timing.
+- In `renderer = "manual"` mode, pass the event pane: `attention.poll(window, { active_pane = pane })`. The plugin resolves `window:active_pane()` at use time; the event pane is used only when the current pane is unavailable.
 
 **Tab titles look wrong?**
 - WezTerm only runs the **first** registered `format-tab-title` handler. If you have your own handler, set `renderer = "manual"` and use `wrap_title_formatter()` or the plugin API. Two handlers cannot coexist.

--- a/examples/hook.sh
+++ b/examples/hook.sh
@@ -15,14 +15,14 @@ mkdir -p "$MARKER_DIR"
 # Write a "stop" marker (tab shows ✓ in mint)
 # Atomic: write to .tmp then rename to avoid partial reads
 if command -v uuidgen >/dev/null 2>&1; then
-  REVISION="$(uuidgen)"
+  PUBLICATION_ID="$(uuidgen)"
 else
-  REVISION="$(od -An -N16 -tx1 /dev/urandom | tr -d ' \n')"
+  PUBLICATION_ID="$(od -An -N16 -tx1 /dev/urandom | tr -d ' \n')"
 fi
-printf '{"type":"stop","revision":"%s","updated_at":%s}\n' "$REVISION" "$(date +%s)" > "${MARKER_DIR}/${WEZTERM_PANE}.tmp"
+printf '{"type":"stop","publication_id":"%s","updated_at":%s}\n' "$PUBLICATION_ID" "$(date +%s)" > "${MARKER_DIR}/${WEZTERM_PANE}.tmp"
 mv "${MARKER_DIR}/${WEZTERM_PANE}.tmp" "${MARKER_DIR}/${WEZTERM_PANE}"
 
-# Other payloads (include a fresh revision when writing them):
+# Other payloads (include a fresh publication ID when writing them):
 #   {"type":"notify"}                # tab shows ! in rose
 #   {"type":"thinking","frame":0}  # animated spinner
 #   {"type":"review"}                # tab shows ◆ in gold

--- a/examples/hook.sh
+++ b/examples/hook.sh
@@ -14,10 +14,15 @@ mkdir -p "$MARKER_DIR"
 
 # Write a "stop" marker (tab shows ✓ in mint)
 # Atomic: write to .tmp then rename to avoid partial reads
-printf '{"type":"stop","updated_at":%s}\n' "$(date +%s)" > "${MARKER_DIR}/${WEZTERM_PANE}.tmp"
+if command -v uuidgen >/dev/null 2>&1; then
+  REVISION="$(uuidgen)"
+else
+  REVISION="$(od -An -N16 -tx1 /dev/urandom | tr -d ' \n')"
+fi
+printf '{"type":"stop","revision":"%s","updated_at":%s}\n' "$REVISION" "$(date +%s)" > "${MARKER_DIR}/${WEZTERM_PANE}.tmp"
 mv "${MARKER_DIR}/${WEZTERM_PANE}.tmp" "${MARKER_DIR}/${WEZTERM_PANE}"
 
-# Other types:
-#   echo '{"type":"notify"}'           # tab shows ! in rose
-#   echo '{"type":"thinking","frame":0}'  # animated spinner
-#   echo '{"type":"review"}'           # tab shows ◆ in gold
+# Other payloads (include a fresh revision when writing them):
+#   {"type":"notify"}                # tab shows ! in rose
+#   {"type":"thinking","frame":0}  # animated spinner
+#   {"type":"review"}                # tab shows ◆ in gold

--- a/examples/hook.ts
+++ b/examples/hook.ts
@@ -27,7 +27,11 @@ async function writeMarker(type: AttentionType, frame?: number): Promise<void> {
   const dir = join(home, ".local", "state", "wezterm-attention");
   await mkdir(dir, { recursive: true });
 
-  const data: Record<string, unknown> = { type, revision: randomUUID(), updated_at: Date.now() };
+  const data: Record<string, unknown> = {
+    type,
+    publication_id: randomUUID(),
+    updated_at: Date.now(),
+  };
   if (frame !== undefined) data.frame = frame;
 
   // Atomic write: tmp file + rename avoids partial reads

--- a/examples/hook.ts
+++ b/examples/hook.ts
@@ -12,6 +12,7 @@
 // The WEZTERM_PANE env var is set automatically by WezTerm for every shell.
 
 import { mkdir, writeFile, rename } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
 import { join } from "node:path";
 
 type AttentionType = "thinking" | "stop" | "notify" | "review";
@@ -26,7 +27,7 @@ async function writeMarker(type: AttentionType, frame?: number): Promise<void> {
   const dir = join(home, ".local", "state", "wezterm-attention");
   await mkdir(dir, { recursive: true });
 
-  const data: Record<string, unknown> = { type, updated_at: Date.now() };
+  const data: Record<string, unknown> = { type, revision: randomUUID(), updated_at: Date.now() };
   if (frame !== undefined) data.frame = frame;
 
   // Atomic write: tmp file + rename avoids partial reads

--- a/examples/wezterm.lua
+++ b/examples/wezterm.lua
@@ -162,8 +162,10 @@ config.status_update_interval = 5000
 local git_cache = { cwd = "", diff = "", branch = "", untracked = 0, ahead = 0, is_repo = false, last = 0 }
 
 wezterm.on('update-status', function(window, pane)
-  -- Poll attention markers (manual mode — plugin doesn't own this event)
-  attention.poll(window)
+  -- Poll attention markers (manual mode — plugin doesn't own this event).
+  -- Passing the event pane gives older WezTerm builds a compatibility
+  -- transport for redraws. Current builds resolve the active pane at use time.
+  attention.poll(window, { active_pane = pane })
 
   local git_cells_prefix = {}
   local cwd_uri = pane:get_current_working_dir()

--- a/pi/index.ts
+++ b/pi/index.ts
@@ -16,7 +16,7 @@ type AttentionState = "thinking" | "stop" | "notify" | "review";
 type Marker = {
 	type: AttentionState;
 	source: "pi";
-	revision: string;
+	publication_id: string;
 	updated_at: number;
 	label?: string;
 	ttl_ms?: number;
@@ -99,17 +99,17 @@ async function writeMarkerNow(state: AttentionState, label?: string): Promise<vo
 	const dir = markerDirectory();
 	if (!dir) return;
 	const path = join(dir, id);
-	const revision = randomUUID();
+	const publicationId = randomUUID();
 	const marker: Marker = {
 		type: state,
 		source: "pi",
-		revision,
+		publication_id: publicationId,
 		updated_at: Date.now(),
 	};
 	if (label) marker.label = label;
 	if (state === "thinking") marker.ttl_ms = ttlMs();
 
-	const tmp = `${path}.tmp.${revision}`;
+	const tmp = `${path}.tmp.${publicationId}`;
 	try {
 		await mkdir(dir, { recursive: true });
 		await writeFile(tmp, JSON.stringify(marker) + "\n");

--- a/pi/index.ts
+++ b/pi/index.ts
@@ -16,6 +16,7 @@ type AttentionState = "thinking" | "stop" | "notify" | "review";
 type Marker = {
 	type: AttentionState;
 	source: "pi";
+	revision: string;
 	updated_at: number;
 	label?: string;
 	ttl_ms?: number;
@@ -98,15 +99,17 @@ async function writeMarkerNow(state: AttentionState, label?: string): Promise<vo
 	const dir = markerDirectory();
 	if (!dir) return;
 	const path = join(dir, id);
+	const revision = randomUUID();
 	const marker: Marker = {
 		type: state,
 		source: "pi",
+		revision,
 		updated_at: Date.now(),
 	};
 	if (label) marker.label = label;
 	if (state === "thinking") marker.ttl_ms = ttlMs();
 
-	const tmp = `${path}.tmp.${randomUUID()}`;
+	const tmp = `${path}.tmp.${revision}`;
 	try {
 		await mkdir(dir, { recursive: true });
 		await writeFile(tmp, JSON.stringify(marker) + "\n");

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -157,8 +157,10 @@ local function read_marker(dir, pane_id)
     return wezterm.json_parse(content)
   end)
   if ok and data and valid_types[data.type] then
-    local revision = type(data.revision) == "string" and data.revision ~= "" and data.revision or nil
-    return data.type, data.frame, normalize_epoch_ms(data.updated_at or data.updated_at_ms), data.ttl_ms, content, revision
+    local publication_id = type(data.publication_id) == "string"
+      and data.publication_id ~= "" and data.publication_id or nil
+    return data.type, data.frame, normalize_epoch_ms(data.updated_at or data.updated_at_ms),
+      data.ttl_ms, content, publication_id
   end
 
   -- Fallback: plain text (backward compat)
@@ -168,20 +170,22 @@ local function read_marker(dir, pane_id)
 end
 
 local acknowledgement_errors = {}
-local revision_counter = 0
-local revision_session = tostring({}):gsub("[^%w]", "")
+local publication_counter = 0
+local publication_session = tostring({}):gsub("[^%w]", "")
 
-local function next_marker_revision()
-  revision_counter = revision_counter + 1
-  return table.concat({ tostring(math.floor(now_ms())), revision_session, revision_counter }, "-")
+local function next_publication_id()
+  publication_counter = publication_counter + 1
+  return table.concat({
+    tostring(math.floor(now_ms())), publication_session, publication_counter,
+  }, "-")
 end
 
 local function acknowledgement_path(dir, pane_id)
   return dir .. "/" .. pane_id .. ".ack"
 end
 
-local function marker_identity(revision, raw)
-  if revision then return "revision\n" .. revision end
+local function marker_identity(publication_id, raw)
+  if publication_id then return "publication\n" .. publication_id end
   return "raw\n" .. (raw or "")
 end
 
@@ -251,14 +255,14 @@ local function write_acknowledgement(dir, pane_id, identity)
   return true
 end
 
-local function acknowledgement_matches(dir, pane_id, raw, revision)
+local function acknowledgement_matches(dir, pane_id, raw, publication_id)
   local acknowledged = read_acknowledgement(dir, pane_id)
   if not raw then
     if acknowledged then clear_acknowledgement(dir, pane_id) end
     return false
   end
 
-  local identity = marker_identity(revision, raw)
+  local identity = marker_identity(publication_id, raw)
   if acknowledged == identity then return true end
 
   -- Cleanup is best-effort. A stale sidecar never suppresses absent or
@@ -270,9 +274,9 @@ end
 local function read_effective_marker(dir, pane_id)
   -- A crash can strand only the temporary sidecar. It was never authoritative.
   os.remove(acknowledgement_path(dir, pane_id) .. ".tmp")
-  local atype, frame, updated_at, marker_ttl_ms, raw, revision = read_marker(dir, pane_id)
-  if acknowledgement_matches(dir, pane_id, raw, revision) then return nil end
-  return atype, frame, updated_at, marker_ttl_ms, raw, revision
+  local atype, frame, updated_at, marker_ttl_ms, raw, publication_id = read_marker(dir, pane_id)
+  if acknowledgement_matches(dir, pane_id, raw, publication_id) then return nil end
+  return atype, frame, updated_at, marker_ttl_ms, raw, publication_id
 end
 
 local function remove_marker(dir, pane_id)
@@ -457,7 +461,7 @@ local function acknowledge_focused_pane(pane_id, opts)
   local cached = attention_cache[id]
   if not (cached and acknowledge_set[cached.type]) then return "absent" end
 
-  local current_type, current_frame, _, _, raw, revision = read_marker(dir, id)
+  local current_type, current_frame, _, _, raw, publication_id = read_marker(dir, id)
   if not current_type then
     clear_acknowledgement(dir, id)
     attention_cache[id] = nil
@@ -471,7 +475,7 @@ local function acknowledge_focused_pane(pane_id, opts)
   end
 
   local write_ack = (opts and opts.write_acknowledgement) or write_acknowledgement
-  if not write_ack(dir, id, marker_identity(revision, raw)) then
+  if not write_ack(dir, id, marker_identity(publication_id, raw)) then
     cache_marker_values(id, current_type, current_frame, raw, observed_now)
     return "failed"
   end
@@ -671,8 +675,8 @@ function M.poll(window, opts)
   for _, tab in ipairs(mux_tabs) do
     for _, p in ipairs(tab:panes()) do
       local id = tostring(p:pane_id())
-      local atype, frame, updated_at, marker_ttl_ms, raw, revision = read_marker(dir, id)
-      local acknowledged = acknowledgement_matches(dir, id, raw, revision)
+      local atype, frame, updated_at, marker_ttl_ms, raw, publication_id = read_marker(dir, id)
+      local acknowledged = acknowledgement_matches(dir, id, raw, publication_id)
       if atype then
         local cached = attention_cache[id]
         local observed_at = now
@@ -972,8 +976,8 @@ function M.apply_to_config(config, opts)
           wezterm.log_error("wezterm-attention: failed to write review marker " .. path)
           return
         end
-        local revision = next_marker_revision()
-        local raw = '{"type":"review","revision":"' .. revision .. '"}'
+        local publication_id = next_publication_id()
+        local raw = '{"type":"review","publication_id":"' .. publication_id .. '"}'
         w:write(raw)
         w:close()
         if os.rename(tmp, path) then

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -31,10 +31,17 @@ local defaults = {
     review = "◆ ",
   },
 
+  -- Generated thinking frames are derived from wall-clock buckets. The
+  -- default matches WezTerm's default status update interval.
+  frame_interval_ms = 1000,
+
+  -- Backstop for unexpected event feedback from the redraw action.
+  max_redraws_per_second = 4,
+
   -- Higher index = higher priority when multiple panes have attention
   priority = { "thinking", "review", "stop", "notify" },
 
-  -- These types auto-clear when their pane becomes active
+  -- These types are acknowledged when their pane becomes active
   auto_clear = { "stop", "notify" },
 
   -- Stale marker cleanup by type, in milliseconds. Prevents zombie busy tabs
@@ -48,8 +55,68 @@ local defaults = {
 -- Known attention types (reject unknown values from marker files)
 local valid_types = { thinking = true, stop = true, notify = true, review = true }
 
-local function now_ms()
+local function coarse_now_ms()
   return os.time() * 1000
+end
+
+-- Bind one wall-clock source for this Lua generation. `%s%3f` is Chrono's
+-- seconds-plus-three-fractional-digits form, which produces integer epoch
+-- milliseconds. Builds without that API use the known one-second fallback.
+local clock_resolution = 1000
+local clock_now_ms = coarse_now_ms
+local clock_fallback_reported = false
+
+local function wezterm_clock_ms()
+  local value = tonumber(wezterm.time.now():format_utc("%s%3f"))
+  if not value or value < 1000000000000 then
+    error("unexpected wezterm.time millisecond value")
+  end
+  return value
+end
+
+if wezterm.time and type(wezterm.time.now) == "function" then
+  local ok = pcall(wezterm_clock_ms)
+  if ok then
+    clock_resolution = 1
+    clock_now_ms = function()
+      local current_ok, value = pcall(wezterm_clock_ms)
+      if current_ok then return value end
+
+      -- A later clock failure must fail coarse, never keep claiming a finer
+      -- resolution than the source can provide.
+      clock_resolution = 1000
+      clock_now_ms = coarse_now_ms
+      if not clock_fallback_reported then
+        clock_fallback_reported = true
+        wezterm.log_error("wezterm-attention: high-resolution clock failed; using one-second animation buckets")
+      end
+      return clock_now_ms()
+    end
+  end
+end
+
+local function now_ms()
+  return clock_now_ms()
+end
+
+local function clock_resolution_ms()
+  return clock_resolution
+end
+
+local function positive_number(value, fallback)
+  local number = tonumber(value)
+  if not number or number <= 0 or number ~= number then return fallback end
+  return number
+end
+
+local function effective_frame_interval_ms()
+  local configured = M._active_frame_interval_ms or defaults.frame_interval_ms
+  return math.max(configured, clock_resolution_ms())
+end
+
+local function frame_for_now(poll_now_ms, frame_count)
+  if frame_count <= 0 then return 0 end
+  return math.floor(poll_now_ms / effective_frame_interval_ms()) % frame_count
 end
 
 local function normalize_epoch_ms(value)
@@ -90,7 +157,8 @@ local function read_marker(dir, pane_id)
     return wezterm.json_parse(content)
   end)
   if ok and data and valid_types[data.type] then
-    return data.type, data.frame, normalize_epoch_ms(data.updated_at or data.updated_at_ms), data.ttl_ms, content
+    local revision = type(data.revision) == "string" and data.revision ~= "" and data.revision or nil
+    return data.type, data.frame, normalize_epoch_ms(data.updated_at or data.updated_at_ms), data.ttl_ms, content, revision
   end
 
   -- Fallback: plain text (backward compat)
@@ -99,13 +167,123 @@ local function read_marker(dir, pane_id)
   return nil
 end
 
+local acknowledgement_errors = {}
+local revision_counter = 0
+local revision_session = tostring({}):gsub("[^%w]", "")
+
+local function next_marker_revision()
+  revision_counter = revision_counter + 1
+  return table.concat({ tostring(math.floor(now_ms())), revision_session, revision_counter }, "-")
+end
+
+local function acknowledgement_path(dir, pane_id)
+  return dir .. "/" .. pane_id .. ".ack"
+end
+
+local function marker_identity(revision, raw)
+  if revision then return "revision\n" .. revision end
+  return "raw\n" .. (raw or "")
+end
+
+local function read_acknowledgement(dir, pane_id)
+  local file = io.open(acknowledgement_path(dir, pane_id), "r")
+  if not file then return nil end
+  local identity = file:read("*a")
+  file:close()
+  return identity
+end
+
+local function report_acknowledgement_error_once(key, message)
+  if acknowledgement_errors[key] then return end
+  acknowledgement_errors[key] = true
+  wezterm.log_error("wezterm-attention: " .. message)
+end
+
+local function clear_acknowledgement(dir, pane_id)
+  local path = acknowledgement_path(dir, pane_id)
+  local existing = io.open(path, "r")
+  if not existing then return true end
+  existing:close()
+
+  local ok, err = os.remove(path)
+  if ok then return true end
+  report_acknowledgement_error_once(
+    "clear:" .. pane_id,
+    "failed to remove acknowledgement " .. path .. ": " .. tostring(err))
+  return false
+end
+
+local function write_acknowledgement(dir, pane_id, identity)
+  local path = acknowledgement_path(dir, pane_id)
+  local tmp = path .. ".tmp"
+  os.remove(tmp)
+  local file, open_err = io.open(tmp, "w")
+  if not file then
+    report_acknowledgement_error_once(
+      "write:" .. pane_id,
+      "failed to write acknowledgement " .. tmp .. ": " .. tostring(open_err))
+    return false
+  end
+
+  local wrote, write_err = file:write(identity)
+  local closed, close_err = file:close()
+  if not wrote or not closed then
+    os.remove(tmp)
+    report_acknowledgement_error_once(
+      "write:" .. pane_id,
+      "failed to finish acknowledgement " .. tmp .. ": " .. tostring(write_err or close_err))
+    return false
+  end
+
+  if not clear_acknowledgement(dir, pane_id) then
+    os.remove(tmp)
+    return false
+  end
+
+  local renamed, rename_err = os.rename(tmp, path)
+  if not renamed then
+    os.remove(tmp)
+    report_acknowledgement_error_once(
+      "write:" .. pane_id,
+      "failed to place acknowledgement " .. path .. ": " .. tostring(rename_err))
+    return false
+  end
+  return true
+end
+
+local function acknowledgement_matches(dir, pane_id, raw, revision)
+  local acknowledged = read_acknowledgement(dir, pane_id)
+  if not raw then
+    if acknowledged then clear_acknowledgement(dir, pane_id) end
+    return false
+  end
+
+  local identity = marker_identity(revision, raw)
+  if acknowledged == identity then return true end
+
+  -- Cleanup is best-effort. A stale sidecar never suppresses absent or
+  -- mismatched canonical truth even when it cannot be removed.
+  if acknowledged then clear_acknowledgement(dir, pane_id) end
+  return false
+end
+
+local function read_effective_marker(dir, pane_id)
+  -- A crash can strand only the temporary sidecar. It was never authoritative.
+  os.remove(acknowledgement_path(dir, pane_id) .. ".tmp")
+  local atype, frame, updated_at, marker_ttl_ms, raw, revision = read_marker(dir, pane_id)
+  if acknowledgement_matches(dir, pane_id, raw, revision) then return nil end
+  return atype, frame, updated_at, marker_ttl_ms, raw, revision
+end
+
 local function remove_marker(dir, pane_id)
   os.remove(dir .. "/" .. pane_id)
+  clear_acknowledgement(dir, pane_id)
+  os.remove(acknowledgement_path(dir, pane_id) .. ".tmp")
 end
 
 -- ── In-memory cache ─────────────────────────────────────────────────────────
 -- format-tab-title must not poll every pane from disk (it blocks the GUI
--- thread). update-status fills this cache; auto-clear performs one confirmation
+-- thread). update-status fills this cache; acknowledgement performs one confirmation
 -- read only when acknowledging a cached terminal marker.
 
 local attention_cache = {} -- { [pane_id_string] = { type = "stop", frame = 0 } }
@@ -127,9 +305,58 @@ local function default_title(tab)
   return dir_name ~= "" and (dir_name .. " / " .. title) or title
 end
 
---- Get the resolved attention indicator and type for a tab.
---- Considers all panes and applies priority. Returns (indicator, type, color) or ("", nil, nil).
-local function get_tab_attention(tab, opts)
+--- Pane IDs of one tab, as the GUI hands them to format-tab-title.
+local function gui_tab_pane_ids(tab)
+  local ids = {}
+  for _, p in ipairs(tab.panes) do
+    ids[#ids + 1] = tostring(p.pane_id)
+  end
+  return ids
+end
+
+--- Pane IDs of one tab, as the mux hands them to poll().
+local mux_projection_fallback_reported = false
+
+local function mux_tab_pane_ids(tab)
+  local panes_with_info = tab.panes_with_info
+  if type(panes_with_info) == "function" then
+    local ok, infos = pcall(panes_with_info, tab)
+    if ok and type(infos) == "table" then
+      local all = {}
+      local zoomed = {}
+      for _, info in ipairs(infos) do
+        local pane = info.pane
+        if pane then
+          local id = tostring(pane:pane_id())
+          all[#all + 1] = id
+          if info.is_zoomed then zoomed[#zoomed + 1] = id end
+        end
+      end
+      if #zoomed > 0 then return zoomed end
+      return all
+    end
+  end
+
+  if not mux_projection_fallback_reported then
+    mux_projection_fallback_reported = true
+    wezterm.log_error(
+      "wezterm-attention: this WezTerm build does not expose tab:panes_with_info(); " ..
+      "zoomed tabs may redraw on hidden-pane changes")
+  end
+
+  local ids = {}
+  for _, p in ipairs(tab:panes()) do
+    ids[#ids + 1] = tostring(p:pane_id())
+  end
+  return ids
+end
+
+--- Project one tab's panes into exactly what a title formatter can see:
+--- { indicator = string, type = string|nil, color = string|nil }.
+--- Pane IDs are the input, not a GUI or mux tab object, so the renderer and
+--- the poller resolve the same value from the same tab. Panes with no cache
+--- entry contribute nothing.
+local function resolve_visible_attention(pane_ids, opts)
   local cfg_indicators = (opts and opts.indicators) or M._active_indicators or defaults.indicators
   local cfg_colors = (opts and opts.colors) or M._active_colors or defaults.colors
   local cfg_priority = M._active_priority_map or {}
@@ -138,8 +365,8 @@ local function get_tab_attention(tab, opts)
   local best_priority = -1
   local best_frame    = nil
 
-  for _, p in ipairs(tab.panes) do
-    local cached = attention_cache[tostring(p.pane_id)]
+  for _, id in ipairs(pane_ids) do
+    local cached = attention_cache[id]
     if cached then
       local pri = cfg_priority[cached.type] or 0
       if pri > best_priority then
@@ -150,20 +377,32 @@ local function get_tab_attention(tab, opts)
     end
   end
 
-  if not best_type then return "", nil, nil end
+  if not best_type then
+    return { indicator = "", type = nil, color = nil }
+  end
 
   local indicator = ""
   if best_type == "thinking" then
     local frames = cfg_indicators.thinking_frames
-    indicator = frames[((best_frame or 0) % #frames) + 1]
+    if frames and #frames > 0 then
+      indicator = frames[((best_frame or 0) % #frames) + 1]
+    end
   elseif cfg_indicators[best_type] then
     indicator = cfg_indicators[best_type]
   end
 
-  return indicator, best_type, cfg_colors[best_type]
+  return { indicator = indicator, type = best_type, color = cfg_colors[best_type] }
 end
 
---- Return the panes of the tab that contains pane_id, or nil if none does.
+--- Two projections are the same iff a viewer could not tell them apart.
+--- Marker bytes, TTL metadata, pane ordering and cache identity are all
+--- deliberately excluded: a change none of these three fields reflects is a
+--- change no tab title would show.
+local function same_visible_attention(a, b)
+  return a.indicator == b.indicator and a.type == b.type and a.color == b.color
+end
+
+--- Return the panes and tab that contain pane_id, or nil if none does.
 --- Uses only mux_win:tabs()/tab:panes() — the same WezTerm API surface poll()
 --- already calls every tick — so it stays within the plugin's compatibility
 --- floor (active_tab()/active_pane() don't exist on the oldest plugin builds).
@@ -172,43 +411,201 @@ local function tab_panes_containing(mux_win, pane_id)
     local panes = tab:panes()
     for _, p in ipairs(panes) do
       if tostring(p:pane_id()) == pane_id then
-        return panes
+        return panes, tab
       end
     end
   end
   return nil
 end
 
---- Auto-clear an applicable marker on the active pane (stop, notify by default).
-local function auto_clear_active_pane(tab)
-  local dir = M._active_dir or defaults.dir
-  local clear_set = M._active_clear_set or { stop = true, notify = true }
-  local pane = tab.active_pane
-  if not pane then return end
+--- Acknowledge the one pane the user is actually looking at: suppress its
+--- effective attention if disk still says its type is one they configured to acknowledge on
+--- sight (stop, notify by default). Canonical writer truth is never moved or
+--- removed; the acknowledged marker identity is written to a sidecar instead.
+---
+--- The caller must already have established that the GUI window has keyboard
+--- focus and that this is its active pane. Both conditions matter: a marker
+--- acknowledged while its window is in the background is a notification the user
+--- never saw.
+---
+local function cache_marker_values(id, atype, frame, raw, observed_now)
+  if not atype then
+    attention_cache[id] = nil
+    return
+  end
 
-  local id = tostring(pane.pane_id)
+  if atype == "thinking" and frame == nil then
+    local cfg_indicators = M._active_indicators or defaults.indicators
+    local frames = cfg_indicators.thinking_frames or defaults.indicators.thinking_frames
+    frame = frame_for_now(observed_now, #frames)
+  end
+
+  attention_cache[id] = {
+    type        = atype,
+    frame       = frame,
+    observed_at = observed_now,
+    raw         = raw,
+  }
+end
+
+local function acknowledge_focused_pane(pane_id, opts)
+  local dir = (opts and opts.dir) or M._active_dir or defaults.dir
+  local acknowledge_set = M._active_acknowledge_set or { stop = true, notify = true }
+  local observed_now = (opts and opts.now_ms) or now_ms()
+
+  local id = tostring(pane_id)
   local cached = attention_cache[id]
-  if cached and clear_set[cached.type] then
-    -- Confirm disk truth before a destructive clear. A new turn can replace a
-    -- cached stop with thinking between poll() and this title callback; deleting
-    -- from the stale cache would erase the new lifecycle state.
-    local current_type, current_frame, updated_at, marker_ttl_ms, raw = read_marker(dir, id)
-    if current_type and clear_set[current_type] then
-      remove_marker(dir, id)
-      attention_cache[id] = nil
-    elseif current_type then
-      attention_cache[id] = {
-        type        = current_type,
-        frame       = current_frame,
-        updated_at  = updated_at,
-        observed_at = now_ms(),
-        ttl_ms      = marker_ttl_ms,
-        raw         = raw,
-      }
-    else
-      attention_cache[id] = nil
+  if not (cached and acknowledge_set[cached.type]) then return "absent" end
+
+  local current_type, current_frame, _, _, raw, revision = read_marker(dir, id)
+  if not current_type then
+    clear_acknowledgement(dir, id)
+    attention_cache[id] = nil
+    return "absent"
+  end
+
+  if not acknowledge_set[current_type] then
+    clear_acknowledgement(dir, id)
+    cache_marker_values(id, current_type, current_frame, raw, observed_now)
+    return "kept"
+  end
+
+  local write_ack = (opts and opts.write_acknowledgement) or write_acknowledgement
+  if not write_ack(dir, id, marker_identity(revision, raw)) then
+    cache_marker_values(id, current_type, current_frame, raw, observed_now)
+    return "failed"
+  end
+
+  -- A writer may replace or clear the marker while the sidecar is being
+  -- written. Re-read effective truth before updating the cache: only the exact
+  -- identity that was viewed is suppressed.
+  local effective_type, effective_frame, _, _, effective_raw = read_effective_marker(dir, id)
+  cache_marker_values(id, effective_type, effective_frame, effective_raw, observed_now)
+  return effective_type and "kept" or "acknowledged"
+end
+
+-- ── Focus and redraw ────────────────────────────────────────────────────────
+
+-- update-status fires several times a second, so a missing WezTerm method is
+-- reported once per process rather than once per tick.
+local reported_missing = {}
+local redraw_budget = {}
+local redraw_budget_reported = false
+local redraw_disabled = {}
+
+local function report_missing_once(method_name)
+  if reported_missing[method_name] then return end
+  reported_missing[method_name] = true
+  wezterm.log_error(
+    "wezterm-attention: this WezTerm build does not expose window:" .. method_name ..
+    "(); inactive tabs will update only on ordinary WezTerm redraws")
+end
+
+local function redraw_window_key(window)
+  local window_id = window.window_id
+  if type(window_id) == "function" then
+    local ok, id = pcall(window_id, window)
+    if ok and id ~= nil then return tostring(id) end
+  end
+  return tostring(window)
+end
+
+local function redraw_allowed(window, poll_now_ms)
+  local limit = math.floor(
+    M._active_max_redraws_per_second or defaults.max_redraws_per_second)
+  if limit <= 0 then return false end
+
+  local key = redraw_window_key(window)
+  local second = math.floor(poll_now_ms / 1000)
+  local budget = redraw_budget[key]
+  if not budget or budget.second ~= second then
+    budget = { second = second, count = 0 }
+    redraw_budget[key] = budget
+  end
+
+  if budget.count >= limit then
+    if not redraw_budget_reported then
+      redraw_budget_reported = true
+      wezterm.log_error("wezterm-attention: tab bar redraw budget exhausted; suppressing excess redraws")
+    end
+    return false
+  end
+
+  budget.count = budget.count + 1
+  return true
+end
+
+--- True only when this GUI window currently has keyboard focus. A build that
+--- cannot answer counts as unfocused, which costs a redraw and never acknowledges a
+--- marker the user has not seen.
+local function window_is_focused(window)
+  local is_focused = window.is_focused
+  if type(is_focused) ~= "function" then
+    report_missing_once("is_focused")
+    return false
+  end
+  local ok, focused = pcall(is_focused, window)
+  return ok and focused == true
+end
+
+--- Resolve current pane truth at use time. The pane captured when
+--- update-status was scheduled can be stale by the time its async callback
+--- runs, so it is never destructive authority.
+local function window_current_active_pane(window)
+  local active_pane = window.active_pane
+  if type(active_pane) ~= "function" then
+    report_missing_once("active_pane")
+    return nil
+  end
+  local ok, resolved = pcall(active_pane, window)
+  if not ok then return nil end
+  return resolved
+end
+
+local function pane_belongs_to_tabs(pane, mux_tabs)
+  if not pane then return false end
+  local target_id = tostring(pane:pane_id())
+  for _, tab in ipairs(mux_tabs) do
+    for _, candidate in ipairs(tab:panes()) do
+      if tostring(candidate:pane_id()) == target_id then return true end
     end
   end
+  return false
+end
+
+--- Ask WezTerm to rebuild every tab title without changing tab selection or
+--- user-owned title and status values.
+---
+--- ActivateTabRelative(0) re-activates the tab that is already active. WezTerm
+--- answers by recomputing the tab bar, which is the whole point; the active
+--- tab, active pane, status strings, mux window title, and user-owned title
+--- values remain intact while attention decoration updates. This is not a
+--- dedicated invalidation API, so it lives behind this one function: if
+--- WezTerm ever ships a real "redraw the tab bar" call, only this body changes.
+---
+--- The caller must have established that the window is focused. Performing a
+--- key action against a background window can emit terminal focus events, so
+--- that guard is correctness, not economy.
+local function request_tab_bar_redraw(window, pane)
+  if not pane then return false end
+
+  local window_key = redraw_window_key(window)
+  if redraw_disabled[window_key] then return false end
+
+  local perform_action = window.perform_action
+  if type(perform_action) ~= "function" then
+    report_missing_once("perform_action")
+    redraw_disabled[window_key] = true
+    return false
+  end
+
+  local ok, err = pcall(perform_action, window, wezterm.action.ActivateTabRelative(0), pane)
+  if not ok then
+    redraw_disabled[window_key] = true
+    wezterm.log_error("wezterm-attention: tab bar redraw failed: " .. tostring(err))
+    return false
+  end
+  return true
 end
 
 -- ── Public API ──────────────────────────────────────────────────────────────
@@ -218,7 +615,7 @@ end
 function M.get_attention(pane_id, opts)
   local id = tostring(pane_id)
   if opts and opts.dir then
-    return read_marker(opts.dir, id)
+    return read_effective_marker(opts.dir, id)
   end
   local cached = attention_cache[id]
   if cached then return cached.type, cached.frame end
@@ -233,8 +630,10 @@ function M.remove_marker(pane_id, opts)
   attention_cache[id] = nil
 end
 
---- Poll marker files and update cache. Call from your own update-status
---- handler if you set auto_poll = false.
+--- Poll marker files, update the cache, acknowledge what the user is looking
+--- at, and ask WezTerm to redraw the tab bar if what it shows has changed.
+--- Call this from your own update-status handler if you set auto_poll = false;
+--- pass the handler's pane as opts.active_pane.
 ---
 --- Only refreshes entries for panes in the current window. Cross-window cache
 --- entries are left alone — pruning them here would cause cache thrash when
@@ -242,19 +641,38 @@ end
 --- entries every tick, producing visible tab-indicator blinking). Stale
 --- thinking markers are removed here by TTL; closed panes are cleaned up by
 --- the pane-destroyed handler.
+---
+--- The redraw exists because caching alone is not enough: WezTerm calls
+--- format-tab-title when something it knows about changes, and a marker file
+--- appearing on disk is not one of those things. Without the request below, a
+--- background pane's new state sat in the cache, unrendered, until the user
+--- happened to switch tabs — which is exactly when they no longer needed to be
+--- told.
 function M.poll(window, opts)
   local dir = (opts and opts.dir) or M._active_dir or defaults.dir
   local mux_win = window:mux_window()
   if not mux_win then return end
 
-  local now = now_ms()
-  local animation_frame = M._poll_animation_frame or 0
-  M._poll_animation_frame = (animation_frame + 1) % 4
+  -- Hold one tab list for the whole poll so the before/after snapshots below
+  -- describe the same tabs in the same order.
+  local mux_tabs = mux_win:tabs()
+  local before = {}
+  for i, tab in ipairs(mux_tabs) do
+    before[i] = resolve_visible_attention(mux_tab_pane_ids(tab))
+  end
 
-  for _, tab in ipairs(mux_win:tabs()) do
+  local now = opts and opts.now_ms
+  if type(now) == "function" then now = now() end
+  if type(now) ~= "number" or now ~= now then now = now_ms() end
+  local cfg_indicators = M._active_indicators or defaults.indicators
+  local frames = cfg_indicators.thinking_frames or defaults.indicators.thinking_frames
+  local frame_count = #frames
+
+  for _, tab in ipairs(mux_tabs) do
     for _, p in ipairs(tab:panes()) do
       local id = tostring(p:pane_id())
-      local atype, frame, updated_at, marker_ttl_ms, raw = read_marker(dir, id)
+      local atype, frame, updated_at, marker_ttl_ms, raw, revision = read_marker(dir, id)
+      local acknowledged = acknowledgement_matches(dir, id, raw, revision)
       if atype then
         local cached = attention_cache[id]
         local observed_at = now
@@ -267,16 +685,20 @@ function M.poll(window, opts)
         if ttl and now - effective_updated_at > ttl then
           remove_marker(dir, id)
           attention_cache[id] = nil
+        elseif acknowledged then
+          attention_cache[id] = nil
         else
           if atype == "thinking" and frame == nil then
-            frame = animation_frame
+            -- A frame is a function of time, never of poll count. The redraw
+            -- action can induce immediate update-status events; every poll in
+            -- the same bucket therefore projects the same frame and the chain
+            -- terminates at the visible-change comparison below.
+            frame = frame_for_now(now, frame_count)
           end
           attention_cache[id] = {
             type        = atype,
             frame       = frame,
-            updated_at  = effective_updated_at,
             observed_at = observed_at,
-            ttl_ms      = ttl,
             raw         = raw,
           }
         end
@@ -285,6 +707,49 @@ function M.poll(window, opts)
       end
     end
   end
+
+  -- Everything below is about the focused window only. An unfocused window
+  -- must neither acknowledge a marker its user has not seen nor be sent a key
+  -- action, so an unfocused poll ends here with the cache correct.
+  if not window_is_focused(window) then return end
+
+  local current_active_pane = window_current_active_pane(window)
+  if pane_belongs_to_tabs(current_active_pane, mux_tabs) then
+    acknowledge_focused_pane(current_active_pane:pane_id(), { dir = dir, now_ms = now })
+  end
+
+  -- The current pane is preferred for both acknowledgement and action. The
+  -- event pane remains a compatibility transport only when this WezTerm build
+  -- cannot resolve current pane state; it never authorizes acknowledgement.
+  local action_pane = current_active_pane or (opts and opts.active_pane)
+
+  -- Compare what the tab bar would show, not what the cache holds. A marker
+  -- that changed behind a higher-priority sibling, or a frame number nothing
+  -- renders, must not cost a redraw.
+  local changed = false
+  for i, tab in ipairs(mux_tabs) do
+    local after = resolve_visible_attention(mux_tab_pane_ids(tab))
+    if not same_visible_attention(before[i], after) then
+      changed = true
+      break
+    end
+  end
+
+  if changed and redraw_allowed(window, now) then
+    request_tab_bar_redraw(window, action_pane)
+  end
+end
+
+--- Apply the shared attention indicator and color decoration to a base title.
+local function decorate_tab_title(tab, visible, base)
+  local text = " " .. visible.indicator .. (tab.tab_index + 1) .. ": " .. base .. " "
+  if visible.color then
+    return {
+      { Background = { Color = visible.color } },
+      { Text = text },
+    }
+  end
+  return text
 end
 
 --- Wrap a user's title function with attention decoration.
@@ -296,11 +761,10 @@ end
 ---   end))
 function M.wrap_title_formatter(base_fn)
   return function(tab, tabs, panes, config, hover, max_width)
-    -- Clear before deriving formatter context so ctx.attention describes only
-    -- attention the user has not seen yet.
-    if tab.is_active then
-      auto_clear_active_pane(tab)
-    end
+    -- Read-only. WezTerm may call this at any moment, including for a window
+    -- the user is not looking at, so acknowledgement belongs in poll() where
+    -- focus is known.
+    local visible = resolve_visible_attention(gui_tab_pane_ids(tab))
 
     local ctx = {
       tabs         = tabs,
@@ -309,23 +773,10 @@ function M.wrap_title_formatter(base_fn)
       hover        = hover,
       max_width    = max_width,
       default_title = default_title(tab),
-      attention    = { get_tab_attention(tab) },
+      attention    = { visible.indicator, visible.type, visible.color },
     }
 
-    local base = base_fn(tab, ctx)
-    local index = tab.tab_index + 1
-
-    local indicator, atype, color = get_tab_attention(tab)
-    local text = " " .. indicator .. index .. ": " .. base .. " "
-
-    if color then
-      return {
-        { Background = { Color = color } },
-        { Text = text },
-      }
-    end
-
-    return text
+    return decorate_tab_title(tab, visible, base_fn(tab, ctx))
   end
 end
 
@@ -364,16 +815,20 @@ function M.apply_to_config(config, opts)
   end
   M._active_indicators = indicators
 
-  local auto_clear = opts.auto_clear or defaults.auto_clear
+  local acknowledge_types = opts.auto_clear or defaults.auto_clear
   local priority   = opts.priority   or defaults.priority
+  M._active_frame_interval_ms = positive_number(opts.frame_interval_ms, defaults.frame_interval_ms)
+  M._active_max_redraws_per_second = positive_number(
+    opts.max_redraws_per_second,
+    defaults.max_redraws_per_second)
   local stale_after_ms = opts.stale_after_ms
   if stale_after_ms == nil then stale_after_ms = defaults.stale_after_ms end
   M._active_stale_after_ms = stale_after_ms
 
   -- Build lookup tables
-  local clear_set = {}
-  for _, t in ipairs(auto_clear) do clear_set[t] = true end
-  M._active_clear_set = clear_set
+  local acknowledge_set = {}
+  for _, t in ipairs(acknowledge_types) do acknowledge_set[t] = true end
+  M._active_acknowledge_set = acknowledge_set
 
   local priority_map = {}
   for i, t in ipairs(priority) do priority_map[t] = i end
@@ -382,8 +837,8 @@ function M.apply_to_config(config, opts)
   -- ── Poller: update-status ─────────────────────────────────────────────
 
   if auto_poll then
-    wezterm.on("update-status", function(window, _pane)
-      M.poll(window)
+    wezterm.on("update-status", function(window, pane)
+      M.poll(window, { active_pane = pane })
     end)
   end
 
@@ -399,39 +854,27 @@ function M.apply_to_config(config, opts)
 
   if renderer == "tab" then
     wezterm.on("format-tab-title", function(tab)
-      local index = tab.tab_index + 1
-
-      -- Clear only the pane the user is viewing. Sibling panes may have
-      -- completed in the background and must remain visible on the active tab.
-      if tab.is_active then
-        auto_clear_active_pane(tab)
-      end
+      -- Read-only. WezTerm may call this at any moment, including for a window
+      -- the user is not looking at, so acknowledgement belongs in poll() where
+      -- focus is known.
+      --
+      -- Resolve what this tab shows, including an unfocused sibling marker
+      -- on the active tab.
+      local visible = resolve_visible_attention(gui_tab_pane_ids(tab))
 
       -- Build base title (user callback or default)
       local base
       if title_formatter then
         local ctx = {
           default_title = default_title(tab),
-          attention     = { get_tab_attention(tab) },
+          attention     = { visible.indicator, visible.type, visible.color },
         }
         base = title_formatter(tab, ctx)
       else
         base = default_title(tab)
       end
 
-      -- Render any remaining attention, including an unfocused sibling marker
-      -- on the active tab.
-      local indicator, attention_type, color = get_tab_attention(tab)
-      local text = " " .. indicator .. index .. ": " .. base .. " "
-
-      if color then
-        return {
-          { Background = { Color = color } },
-          { Text = text },
-        }
-      end
-
-      return text
+      return decorate_tab_title(tab, visible, base)
     end)
   end
   -- renderer == "manual": no format-tab-title registered
@@ -447,14 +890,26 @@ function M.apply_to_config(config, opts)
       key  = review_key.key,
       mods = review_key.mods,
       action = wezterm.action_callback(function(win, pane)
-        -- The review indicator is tab-level: get_tab_attention lights the tab
+        -- The review indicator is tab-level: resolve_visible_attention lights the tab
         -- if ANY of its panes is flagged. So toggle across every pane in the
         -- focused pane's tab — toggling only the focused pane leaves a split
         -- tab stuck showing ◆ (the other pane is still flagged) and unclearable.
         -- Panes not in any tab (GUI overlays) fall back to per-pane behavior.
         local mux_win = win:mux_window()
         local target_id = tostring(pane:pane_id())
-        local panes = (mux_win and tab_panes_containing(mux_win, target_id)) or { pane }
+        local panes, mux_tab
+        if mux_win then panes, mux_tab = tab_panes_containing(mux_win, target_id) end
+        panes = panes or { pane }
+        local visible_pane_ids = mux_tab and mux_tab_pane_ids(mux_tab)
+        local before = visible_pane_ids and resolve_visible_attention(visible_pane_ids)
+
+        local function redraw_if_visible_changed()
+          if not visible_pane_ids then return end
+          local after = resolve_visible_attention(visible_pane_ids)
+          if not same_visible_attention(before, after) then
+            request_tab_bar_redraw(win, pane)
+          end
+        end
 
         -- Decide and act on disk truth, never the cache. poll() rebuilds the
         -- cache from files every tick, so the cache can lag a marker an external
@@ -465,7 +920,7 @@ function M.apply_to_config(config, opts)
         -- the clear path, dropping a completion/failure notification. Read the
         -- file so this destructive toggle only ever removes a real review marker.
         local function is_review(id)
-          return read_marker(dir, id) == "review"
+          return read_effective_marker(dir, id) == "review"
         end
 
         local has_review = false
@@ -486,6 +941,8 @@ function M.apply_to_config(config, opts)
               attention_cache[id] = nil
             end
           end
+          -- The user pressed this key in this window, so it is focused.
+          redraw_if_visible_changed()
           return
         end
 
@@ -495,6 +952,9 @@ function M.apply_to_config(config, opts)
         -- Never clobber a process-owned marker that may have landed since the
         -- last poll: review is a manual overlay, and stop/notify are terminal,
         -- so overwriting one would silently drop a completion/failure signal.
+        -- Use physical writer truth here. An acknowledged terminal marker is
+        -- intentionally absent from effective attention but is still owned by
+        -- its writer and must not be replaced by the review overlay.
         local existing = read_marker(dir, target_id)
         if existing ~= nil and existing ~= "review" then
           return
@@ -512,10 +972,16 @@ function M.apply_to_config(config, opts)
           wezterm.log_error("wezterm-attention: failed to write review marker " .. path)
           return
         end
-        w:write('{"type":"review"}')
+        local revision = next_marker_revision()
+        local raw = '{"type":"review","revision":"' .. revision .. '"}'
+        w:write(raw)
         w:close()
         if os.rename(tmp, path) then
-          attention_cache[target_id] = { type = "review" }
+          attention_cache[target_id] = {
+            type = "review",
+            raw = raw,
+          }
+          redraw_if_visible_changed()
         else
           os.remove(tmp)
           wezterm.log_error("wezterm-attention: failed to place review marker " .. path)
@@ -524,5 +990,16 @@ function M.apply_to_config(config, opts)
     })
   end
 end
+
+-- Internal seams, exposed for the LuaJIT specs only. Not public API.
+M._internal = {
+  acknowledge_focused_pane = acknowledge_focused_pane,
+  clock_resolution_ms      = clock_resolution_ms,
+  effective_frame_interval_ms = effective_frame_interval_ms,
+  gui_tab_pane_ids         = gui_tab_pane_ids,
+  mux_tab_pane_ids         = mux_tab_pane_ids,
+  resolve_visible_attention = resolve_visible_attention,
+  same_visible_attention   = same_visible_attention,
+}
 
 return M

--- a/tests/auto_clear_spec.lua
+++ b/tests/auto_clear_spec.lua
@@ -9,19 +9,40 @@ local test_dir = os.tmpname()
 os.remove(test_dir)
 assert(os.execute("mkdir -p " .. shell_quote(test_dir)) == 0)
 
+local logged_errors = {}
+
+local function drain_errors()
+  local drained = {}
+  for i, message in ipairs(logged_errors) do
+    drained[i] = message
+    logged_errors[i] = nil
+  end
+  return drained
+end
+
 local handlers = {}
 local wezterm = {
   home_dir = test_dir,
   action_callback = function(callback) return callback end,
+  action = {
+    -- Recorded, not executed. What the real action does to a live WezTerm is
+    -- the subject of the focused-window rehearsal, not of this file.
+    ActivateTabRelative = function(delta)
+      return { ActivateTabRelative = delta }
+    end,
+  },
   json_parse = function(content)
     return {
       type = content:match('"type"%s*:%s*"([^"]+)"'),
       frame = tonumber(content:match('"frame"%s*:%s*(%d+)')),
       updated_at = tonumber(content:match('"updated_at"%s*:%s*(%d+)')),
+      updated_at_ms = tonumber(content:match('"updated_at_ms"%s*:%s*(%d+)')),
+      ttl_ms = tonumber(content:match('"ttl_ms"%s*:%s*(%d+)')),
+      revision = content:match('"revision"%s*:%s*"([^"]+)"'),
     }
   end,
   log_error = function(message)
-    error(message)
+    table.insert(logged_errors, message)
   end,
   on = function(event, callback)
     handlers[event] = handlers[event] or {}
@@ -32,8 +53,7 @@ local wezterm = {
 package.preload.wezterm = function() return wezterm end
 
 local attention = dofile(repo_root .. "/plugin/init.lua")
-local config = {}
-attention.apply_to_config(config, {
+attention.apply_to_config({}, {
   auto_poll = false,
   dir = test_dir,
   review_key = false,
@@ -44,17 +64,44 @@ local format_tab_title = assert(
   "format-tab-title handler was not registered"
 )
 
-local function write_marker(pane_id, marker_type)
+local pane_destroyed = assert(
+  handlers["pane-destroyed"] and handlers["pane-destroyed"][1],
+  "pane-destroyed handler was not registered"
+)
+
+local internal = assert(attention._internal, "internal seams were not exposed")
+
+-- ── Fixtures ────────────────────────────────────────────────────────────────
+
+local function write_marker(pane_id, marker_type, revision)
   local file = assert(io.open(test_dir .. "/" .. pane_id, "w"))
-  file:write(string.format('{"type":"%s"}', marker_type))
+  if revision then
+    file:write(string.format('{"type":"%s","revision":"%s"}', marker_type, revision))
+  else
+    file:write(string.format('{"type":"%s"}', marker_type))
+  end
   file:close()
 end
 
-local function marker_exists(pane_id)
-  local file = io.open(test_dir .. "/" .. pane_id, "r")
+local function path_exists(path)
+  local file = io.open(path, "r")
   if not file then return false end
   file:close()
   return true
+end
+
+local function marker_exists(pane_id)
+  return path_exists(test_dir .. "/" .. pane_id)
+end
+
+local function acknowledgement_exists(pane_id)
+  return path_exists(test_dir .. "/" .. pane_id .. ".ack")
+end
+
+local function write_acknowledgement_file(pane_id, identity)
+  local file = assert(io.open(test_dir .. "/" .. pane_id .. ".ack", "w"))
+  file:write(identity)
+  file:close()
 end
 
 local function mux_pane(pane_id)
@@ -70,23 +117,104 @@ local function gui_pane(pane_id)
   }
 end
 
-local function poll(pane_ids)
-  local panes = {}
-  for _, pane_id in ipairs(pane_ids) do
-    table.insert(panes, mux_pane(pane_id))
+--- A GUI window double. It records the actions the plugin performs and every
+--- status or title write it attempts, so a test can assert what the plugin
+--- left alone as readily as what it changed.
+---
+--- spec = {
+---   tabs           = { { pane_id, ... }, ... },
+---   focused        = boolean,
+---   active_pane_id = pane_id | nil,
+---   action_error   = string | nil,   -- make perform_action throw
+---   on_action      = function | nil, -- observe or re-enter perform_action
+---   omit           = { method_name = true },  -- pretend an older build
+--- }
+local next_window_id = 0
+
+local function window_double(spec)
+  next_window_id = next_window_id + 1
+  local assigned_window_id = spec.window_id or next_window_id
+  local mux_tabs = {}
+  for _, pane_ids in ipairs(spec.tabs or {}) do
+    local panes = {}
+    for _, pane_id in ipairs(pane_ids) do
+      table.insert(panes, mux_pane(pane_id))
+    end
+    table.insert(mux_tabs, {
+      panes = function() return panes end,
+      panes_with_info = function()
+        local infos = {}
+        for _, pane in ipairs(panes) do
+          infos[#infos + 1] = { pane = pane, is_zoomed = false }
+        end
+        return infos
+      end,
+    })
   end
 
-  local mux_tab = {
-    panes = function() return panes end,
-  }
-  local mux_window = {
-    tabs = function() return { mux_tab } end,
-  }
-  local window = {
-    mux_window = function() return mux_window end,
+  local w = {
+    actions           = {},
+    status_writes     = {},
+    title_writes      = {},
+    active_pane_calls = 0,
+    action_calls      = 0,
   }
 
-  attention.poll(window)
+  function w.mux_window()
+    return { tabs = function() return mux_tabs end }
+  end
+
+  function w.window_id()
+    return assigned_window_id
+  end
+
+  function w.is_focused()
+    if spec.on_focus_check then spec.on_focus_check() end
+    return spec.focused == true
+  end
+
+  function w.active_pane()
+    w.active_pane_calls = w.active_pane_calls + 1
+    if spec.active_pane_id == nil then return nil end
+    return mux_pane(spec.active_pane_id)
+  end
+
+  function w.perform_action(_, action, pane)
+    w.action_calls = w.action_calls + 1
+    if spec.action_error then error(spec.action_error, 0) end
+    table.insert(w.actions, { action = action, pane_id = pane and pane:pane_id() })
+    if spec.on_action then spec.on_action(w, action, pane) end
+  end
+
+  function w.set_left_status(_, text) table.insert(w.status_writes, text) end
+  function w.set_right_status(_, text) table.insert(w.status_writes, text) end
+  function w.set_title(_, text) table.insert(w.title_writes, text) end
+
+  for name in pairs(spec.omit or {}) do w[name] = nil end
+
+  return w
+end
+
+--- Poll a single unfocused tab. Used wherever a test only needs the cache
+--- filled and wants no acknowledgement or redraw in the way.
+local function poll(pane_ids)
+  attention.poll(window_double({ tabs = { pane_ids }, focused = false }))
+end
+
+--- Poll as the focused window, returning the double so the test can inspect
+--- the recorded actions.
+local function poll_focused(spec)
+  local w = window_double({
+    tabs           = spec.tabs,
+    focused        = true,
+    active_pane_id = spec.active_pane_id,
+    action_error   = spec.action_error,
+    on_action      = spec.on_action,
+    omit           = spec.omit,
+    on_focus_check = spec.on_focus_check,
+  })
+  attention.poll(w, spec.opts)
+  return w
 end
 
 local function tab(active_pane_id, sibling_pane_id, is_active)
@@ -104,7 +232,11 @@ local passed = 0
 local failed = 0
 
 local function test(name, callback)
+  drain_errors()
   local ok, err = pcall(callback)
+  if ok and #logged_errors > 0 then
+    ok, err = false, "unexpected wezterm.log_error: " .. tostring(logged_errors[1])
+  end
   if ok then
     passed = passed + 1
     io.write("ok - " .. name .. "\n")
@@ -114,73 +246,742 @@ local function test(name, callback)
   end
 end
 
-test("default renderer clears only the focused pane", function()
+-- ── U1: visible-attention projection ────────────────────────────────────────
+
+test("GUI and mux adapters project the same pane IDs in the same order", function()
+  local gui_tab = tab(701, 702, false)
+  local mux_tab = {
+    panes = function() return { mux_pane(701), mux_pane(702) } end,
+    panes_with_info = function()
+      return {
+        { pane = mux_pane(701), is_zoomed = false },
+        { pane = mux_pane(702), is_zoomed = false },
+      }
+    end,
+  }
+
+  local gui_ids = internal.gui_tab_pane_ids(gui_tab)
+  local mux_ids = internal.mux_tab_pane_ids(mux_tab)
+
+  assert(#gui_ids == 2 and #mux_ids == 2, "both adapters should return two pane IDs")
+  assert(gui_ids[1] == mux_ids[1] and gui_ids[2] == mux_ids[2], "adapter outputs should agree")
+  assert(gui_ids[1] == "701", "pane IDs should be strings, got " .. tostring(gui_ids[1]))
+end)
+
+test("mux projection matches the GUI pane set while a split is zoomed", function()
+  local mux_tab = {
+    panes = function() return { mux_pane(703), mux_pane(704) } end,
+    panes_with_info = function()
+      return {
+        { pane = mux_pane(703), is_zoomed = false },
+        { pane = mux_pane(704), is_zoomed = true },
+      }
+    end,
+  }
+  local gui_tab = { panes = { gui_pane(704) } }
+
+  local gui_ids = internal.gui_tab_pane_ids(gui_tab)
+  local mux_ids = internal.mux_tab_pane_ids(mux_tab)
+
+  assert(#mux_ids == 1 and mux_ids[1] == "704",
+    "a zoomed mux tab should project only pane 704")
+  assert(#gui_ids == 1 and gui_ids[1] == mux_ids[1],
+    "GUI and mux projections should agree under zoom")
+end)
+
+test("mux projection falls back once when zoom metadata is unavailable", function()
+  local legacy_tab = { panes = function() return { mux_pane(705), mux_pane(706) } end }
+
+  local first = internal.mux_tab_pane_ids(legacy_tab)
+  local second = internal.mux_tab_pane_ids(legacy_tab)
+  assert(#first == 2 and #second == 2, "legacy fallback should retain every pane")
+
+  local errors = drain_errors()
+  assert(#errors == 1 and errors[1]:find("panes_with_info", 1, true),
+    "the compatibility fallback should log once, got " .. tostring(errors[1]))
+end)
+
+test("projection returns the highest-priority cached pane and ignores uncached ones", function()
+  write_marker(711, "thinking")
+  write_marker(712, "notify")
+  poll({ 711, 712 })
+
+  local visible = internal.resolve_visible_attention({ "711", "712", "799" })
+  assert(visible.type == "notify", "notify outranks thinking, got " .. tostring(visible.type))
+  assert(visible.indicator == "! ", "indicator should be the notify glyph")
+  assert(visible.color == "#240f16", "color should be the notify tint")
+
+  local empty = internal.resolve_visible_attention({ "799" })
+  assert(empty.type == nil and empty.indicator == "" and empty.color == nil,
+    "a pane with no cache entry should project no attention")
+end)
+
+test("visible equality hides changes no tab title would show", function()
+  write_marker(721, "notify")
+  write_marker(722, "notify")
+  poll({ 721, 722 })
+
+  local one  = internal.resolve_visible_attention({ "721" })
+  local both = internal.resolve_visible_attention({ "721", "722" })
+  assert(internal.same_visible_attention(one, both),
+    "a second pane of the same type changes nothing a viewer can see")
+
+  -- 722 drops from notify to stop while 721 still shows notify: the losing
+  -- pane changed, the tab did not.
+  write_marker(722, "stop")
+  poll({ 721, 722 })
+  local masked = internal.resolve_visible_attention({ "721", "722" })
+  assert(internal.same_visible_attention(both, masked),
+    "a change behind the winning pane should compare equal")
+
+  -- 721 drops from notify to review, so stop on 722 becomes the winner.
+  write_marker(721, "review")
+  poll({ 721, 722 })
+  local changed = internal.resolve_visible_attention({ "721", "722" })
+  assert(changed.type == "stop", "stop should outrank review, got " .. tostring(changed.type))
+  assert(not internal.same_visible_attention(masked, changed),
+    "a change to the winning type should compare unequal")
+end)
+
+test("generated thinking frames are stable inside one wall-clock bucket", function()
+  write_marker(731, "thinking")
+  local w = window_double({ tabs = { { 731 } }, focused = false })
+
+  attention.poll(w, { now_ms = 1000 })
+  local _, f0 = attention.get_attention(731)
+  attention.poll(w, { now_ms = 1500 })
+  local _, f1 = attention.get_attention(731)
+  attention.poll(w, { now_ms = 1999 })
+  local _, f2 = attention.get_attention(731)
+  assert(f0 == 1 and f1 == 1 and f2 == 1,
+    "one bucket should keep one frame but got "
+      .. tostring(f0) .. "," .. tostring(f1) .. "," .. tostring(f2))
+
+  attention.poll(w, { now_ms = 2000 })
+  local _, next_frame = attention.get_attention(731)
+  assert(next_frame == 2, "crossing the bucket should advance to frame 2, got " .. tostring(next_frame))
+end)
+
+test("time-derived frames preserve the public get_attention return shape", function()
+  write_marker(732, "thinking")
+  local w = window_double({ tabs = { { 732 } }, focused = false })
+
+  attention.poll(w, { now_ms = 3000 })
+  local state, frame = attention.get_attention(732)
+
+  assert(state == "thinking", "the first return remains the marker type")
+  assert(frame == 3, "the second return remains the derived frame, got " .. tostring(frame))
+end)
+
+test("Lua accepts the revision-bearing marker shape published by Pi", function()
+  local file = assert(io.open(test_dir .. "/733", "w"))
+  file:write('{"type":"notify","source":"pi","revision":"pi-generation",'
+    .. '"updated_at":1000,"label":"done","unknown":"ignored"}')
+  file:close()
+
+  attention.poll(
+    window_double({ tabs = { { 733 } }, focused = false }),
+    { now_ms = 1000000 })
+
+  assert(attention.get_attention(733) == "notify",
+    "Pi's revision and extra fields must not change the marker type")
+end)
+
+test("a coarse clock clamps generated frames to one-second buckets", function()
+  assert(internal.clock_resolution_ms() == 1000,
+    "the LuaJIT harness has no wezterm.time and should bind the coarse fallback")
+  assert(internal.effective_frame_interval_ms() == 1000,
+    "the frame interval must not claim finer resolution than its clock")
+end)
+
+test("a later high-resolution clock failure binds the coarse fallback once", function()
+  local clock_calls = 0
+  wezterm.time = {
+    now = function()
+      return {
+        format_utc = function()
+          clock_calls = clock_calls + 1
+          if clock_calls == 1 then return "1000000000000" end
+          error("clock unavailable", 0)
+        end,
+      }
+    end,
+  }
+
+  local ok, err = pcall(function()
+    local clocked = dofile(repo_root .. "/plugin/init.lua")
+    clocked.apply_to_config({}, {
+      auto_poll = false,
+      dir = test_dir,
+      review_key = false,
+      frame_interval_ms = 10,
+    })
+    assert(clocked._internal.clock_resolution_ms() == 1, "load probe should bind the fine clock")
+
+    write_marker(734, "thinking")
+    local w = window_double({ tabs = { { 734 } }, focused = false })
+    clocked.poll(w)
+    assert(clocked._internal.clock_resolution_ms() == 1000,
+      "runtime failure should switch to coarse resolution")
+    local errors = drain_errors()
+    assert(#errors == 1 and errors[1]:find("high-resolution clock failed", 1, true),
+      "the fallback should log once")
+
+    clocked.poll(w)
+    assert(clock_calls == 2, "the failed high-resolution clock must not be retried")
+    assert(#drain_errors() == 0, "the bound fallback should not log again")
+  end)
+  wezterm.time = nil
+  if not ok then error(err, 0) end
+end)
+
+-- ── U2: read-only rendering ─────────────────────────────────────────────────
+
+test("neither renderer clears a marker, even on the active tab", function()
   write_marker(101, "stop")
   write_marker(102, "notify")
   poll({ 101, 102 })
 
-  local rendered = format_tab_title(tab(101, 102, true))
+  format_tab_title(tab(101, 102, true))
+  attention.wrap_title_formatter(function() return "custom title" end)(tab(101, 102, true))
 
-  assert(not marker_exists(101), "focused pane marker should be cleared")
-  assert(marker_exists(102), "unfocused sibling marker should remain")
-  assert(attention.get_attention(102) == "notify", "sibling cache should remain")
-  assert(type(rendered) == "table", "active tab should render sibling attention styling")
-  assert(rendered[2].Text:find("! ", 1, true), "active tab should show sibling indicator")
+  assert(marker_exists(101), "the active pane's marker must survive rendering")
+  assert(marker_exists(102), "the sibling pane's marker must survive rendering")
+  assert(attention.get_attention(101) == "stop", "rendering must not touch the cache")
+  assert(attention.get_attention(102) == "notify", "rendering must not touch the cache")
 end)
 
-test("manual title wrapper clears only the focused pane", function()
-  write_marker(201, "notify")
-  write_marker(202, "stop")
-  poll({ 201, 202 })
+test("the tab renders the highest-priority pane, sibling included", function()
+  write_marker(111, "review")
+  write_marker(112, "stop")
+  poll({ 111, 112 })
 
-  local formatter_attention
-  local wrapped = attention.wrap_title_formatter(function(_, ctx)
-    formatter_attention = ctx.attention[2]
+  local rendered = format_tab_title(tab(111, 112, true))
+
+  assert(type(rendered) == "table", "an attention tab should carry a tint")
+  assert(rendered[1].Background.Color == "#12271c", "tint should be the stop color")
+  assert(rendered[2].Text:find("✓ ", 1, true), "stop outranks review and should be shown")
+end)
+
+test("both renderers project the same attention for the same tab", function()
+  write_marker(741, "review")
+  write_marker(742, "stop")
+  poll({ 741, 742 })
+
+  local wrapper_attention
+  local wrapper = attention.wrap_title_formatter(function(_, ctx)
+    wrapper_attention = ctx.attention
     return "custom title"
   end)
-  local rendered = wrapped(tab(201, 202, true))
+  local default_rendered = format_tab_title(tab(741, 742, false))
+  local wrapped_rendered = wrapper(tab(741, 742, false))
 
-  assert(not marker_exists(201), "focused pane marker should be cleared")
-  assert(marker_exists(202), "unfocused sibling marker should remain")
-  assert(type(rendered) == "table", "manual wrapper should render sibling attention styling")
-  assert(rendered[2].Text:find("✓ ", 1, true), "manual wrapper should show sibling indicator")
-  assert(formatter_attention == "stop", "formatter context should reflect retained sibling attention")
+  assert(type(default_rendered) == "table" and type(wrapped_rendered) == "table",
+    "both renderers should tint the tab")
+  assert(default_rendered[1].Background.Color == wrapped_rendered[1].Background.Color,
+    "both renderers should pick the same tint")
+  assert(default_rendered[2].Text:find("✓ ", 1, true), "default renderer should show stop")
+  assert(wrapped_rendered[2].Text:find("✓ ", 1, true), "wrapper should show stop")
+  assert(wrapper_attention[1] == "✓ " and wrapper_attention[2] == "stop"
+    and wrapper_attention[3] == "#12271c",
+    "ctx.attention should still be indicator, type, color")
 end)
 
-test("inactive tabs do not clear either pane", function()
-  write_marker(301, "stop")
-  write_marker(302, "notify")
-  poll({ 301, 302 })
+-- ── U2: focus-aware acknowledgement ─────────────────────────────────────────
 
-  format_tab_title(tab(301, 302, false))
+test("a focused poll acknowledges only the active pane", function()
+  write_marker(801, "notify", "rev-801")
+  write_marker(802, "stop")
 
-  assert(marker_exists(301), "inactive tab active-pane marker should remain")
-  assert(marker_exists(302), "inactive tab sibling marker should remain")
+  local w = poll_focused({ tabs = { { 801, 802 } }, active_pane_id = 801 })
+
+  assert(marker_exists(801), "acknowledgement must never remove the canonical marker")
+  assert(acknowledgement_exists(801), "the viewed marker identity should be recorded")
+  assert(marker_exists(802), "an unfocused sibling marker should remain")
+  assert(attention.get_attention(801) == nil, "the acknowledged cache entry should be gone")
+  assert(attention.get_attention(802) == "stop", "the sibling cache entry should remain")
+  assert(#w.status_writes == 0 and #w.title_writes == 0,
+    "the plugin must not write status or title text")
 end)
 
-test("visiting the sibling pane clears its retained marker", function()
+test("an unfocused poll acknowledges nothing and performs no action", function()
+  write_marker(811, "notify")
+  write_marker(812, "stop")
+
+  local w = window_double({ tabs = { { 811, 812 } }, focused = false, active_pane_id = 811 })
+  attention.poll(w)
+
+  assert(marker_exists(811), "a background window must not acknowledge its active pane")
+  assert(marker_exists(812), "a background window must not acknowledge any pane")
+  assert(attention.get_attention(811) == "notify", "the cache should still be filled")
+  assert(#w.actions == 0, "an unfocused window must never be sent a key action")
+end)
+
+test("visiting the sibling pane acknowledges its retained marker", function()
   write_marker(401, "stop")
   write_marker(402, "notify")
-  poll({ 401, 402 })
 
-  format_tab_title(tab(401, 402, true))
-  assert(marker_exists(402), "unfocused sibling marker should initially remain")
+  poll_focused({ tabs = { { 401, 402 } }, active_pane_id = 401 })
+  assert(marker_exists(402), "the unvisited sibling marker should remain")
 
-  format_tab_title(tab(402, 401, true))
-  assert(not marker_exists(402), "marker should clear once its pane is focused")
+  poll_focused({ tabs = { { 401, 402 } }, active_pane_id = 402 })
+  assert(marker_exists(402), "acknowledgement must leave canonical writer truth intact")
+  assert(acknowledgement_exists(402), "the visited sibling should gain an acknowledgement")
+  assert(attention.get_attention(402) == nil, "the acknowledged sibling should disappear from effective cache")
 end)
 
-test("auto-clear never deletes a newer non-clearable marker", function()
-  write_marker(501, "stop")
+test("a new marker revision releases an older acknowledgement", function()
+  write_marker(931, "notify", "generation-g")
+  poll_focused({ tabs = { { 930, 931 } }, active_pane_id = 931 })
+  assert(attention.get_attention(931) == nil, "generation G should be acknowledged")
+
+  write_marker(931, "notify", "generation-h")
+  poll({ 930, 931 })
+
+  assert(attention.get_attention(931) == "notify", "generation H must be visible")
+  assert(not acknowledgement_exists(931), "the stale generation-G acknowledgement should be removed")
+end)
+
+test("legacy raw identity remains compatible and changed bytes become visible", function()
+  write_marker(932, "stop")
+  poll_focused({ tabs = { { 930, 932 } }, active_pane_id = 932 })
+  assert(attention.get_attention(932) == nil, "legacy stop should be acknowledged by raw identity")
+
+  write_marker(932, "notify")
+  poll({ 930, 932 })
+
+  assert(attention.get_attention(932) == "notify", "changed legacy bytes must become visible")
+  assert(not acknowledgement_exists(932), "changed raw identity should release the sidecar")
+end)
+
+test("a stale acknowledgement never suppresses mismatched canonical truth when cleanup fails", function()
+  write_marker(933, "notify", "generation-h")
+  write_acknowledgement_file(933, "revision\ngeneration-g")
+
+  local ack_path = test_dir .. "/933.ack"
+  local real_remove = os.remove
+  os.remove = function(path)
+    if path == ack_path then return nil, "permission denied" end
+    return real_remove(path)
+  end
+  poll({ 933 })
+  os.remove = real_remove
+
+  assert(attention.get_attention(933) == "notify", "mismatched current truth must remain visible")
+  assert(acknowledgement_exists(933), "precondition: failed cleanup leaves the stale sidecar")
+  local errors = drain_errors()
+  assert(#errors == 1 and errors[1]:find("failed to remove acknowledgement", 1, true),
+    "cleanup failure should log once, got " .. tostring(errors[1]))
+end)
+
+test("canonical absence clears acknowledgement without resurrecting state", function()
+  write_marker(941, "stop", "generation-g")
+  poll_focused({ tabs = { { 940, 941 } }, active_pane_id = 941 })
+  assert(acknowledgement_exists(941), "the sidecar should exist after acknowledgement")
+
+  os.remove(test_dir .. "/941")
+  poll({ 940, 941 })
+
+  assert(attention.get_attention(941) == nil, "absence remains clear")
+  assert(not acknowledgement_exists(941), "absence should release stale acknowledgement")
+end)
+
+test("direct disk reads respect acknowledgement identity", function()
+  write_marker(942, "notify", "generation-g")
+  poll_focused({ tabs = { { 940, 942 } }, active_pane_id = 942 })
+
+  assert(attention.get_attention(942, { dir = test_dir }) == nil,
+    "a direct read should expose effective attention, not acknowledged physical state")
+end)
+
+test("acknowledgement survives a plugin reload without moving canonical truth", function()
+  write_marker(947, "notify", "generation-g")
+  poll_focused({ tabs = { { 940, 947 } }, active_pane_id = 947 })
+  assert(acknowledgement_exists(947), "precondition: sidecar exists")
+
+  local reloaded = dofile(repo_root .. "/plugin/init.lua")
+  reloaded.apply_to_config({}, { auto_poll = false, dir = test_dir, review_key = false })
+  reloaded.poll(window_double({ tabs = { { 940, 947 } }, focused = false }))
+
+  assert(marker_exists(947), "reload must leave canonical marker untouched")
+  assert(reloaded.get_attention(947) == nil, "reload should honor the durable acknowledgement")
+end)
+
+test("acknowledgement write failure leaves marker visible and cache truthful", function()
+  write_marker(943, "notify", "generation-g")
+  poll({ 943 })
+
+  local outcome = internal.acknowledge_focused_pane(943, {
+    dir = test_dir,
+    now_ms = 1000,
+    write_acknowledgement = function() return false end,
+  })
+
+  assert(outcome == "failed", "the failure should be explicit, got " .. tostring(outcome))
+  assert(marker_exists(943), "acknowledgement failure must retain canonical truth")
+  assert(not acknowledgement_exists(943), "a failed write must not install a sidecar")
+  assert(attention.get_attention(943) == "notify", "the marker must remain visible")
+end)
+
+test("acknowledgement rename failure removes its temp and leaves truth visible", function()
+  write_marker(948, "notify", "generation-g")
+  poll({ 948 })
+
+  local ack_path = test_dir .. "/948.ack"
+  local real_rename = os.rename
+  os.rename = function(from, to)
+    if to == ack_path then return nil, "permission denied" end
+    return real_rename(from, to)
+  end
+  local ok, outcome = pcall(internal.acknowledge_focused_pane, 948, {
+    dir = test_dir,
+    now_ms = 1000,
+  })
+  os.rename = real_rename
+
+  assert(ok and outcome == "failed", "rename failure should return failed")
+  assert(marker_exists(948), "canonical truth must remain")
+  assert(not acknowledgement_exists(948), "failed rename must not install acknowledgement")
+  assert(not path_exists(ack_path .. ".tmp"), "failed rename must remove its temp file")
+  assert(attention.get_attention(948) == "notify", "failed acknowledgement must remain visible")
+  local errors = drain_errors()
+  assert(#errors == 1 and errors[1]:find("failed to place acknowledgement", 1, true),
+    "the real rename failure should be logged")
+end)
+
+test("public removal clears canonical marker and acknowledgement sidecar", function()
+  write_marker(944, "stop", "generation-g")
+  poll_focused({ tabs = { { 940, 944 } }, active_pane_id = 944 })
+  assert(acknowledgement_exists(944), "precondition: sidecar exists")
+
+  attention.remove_marker(944, { dir = test_dir })
+
+  assert(not marker_exists(944), "public removal should remove canonical marker")
+  assert(not acknowledgement_exists(944), "public removal should remove sidecar")
+  assert(attention.get_attention(944) == nil, "public removal should clear cache")
+end)
+
+test("pane destruction clears canonical marker and acknowledgement sidecar", function()
+  write_marker(945, "notify", "generation-g")
+  poll_focused({ tabs = { { 940, 945 } }, active_pane_id = 945 })
+  assert(acknowledgement_exists(945), "precondition: sidecar exists")
+
+  pane_destroyed(nil, mux_pane(945))
+
+  assert(not marker_exists(945), "pane destruction should remove canonical marker")
+  assert(not acknowledgement_exists(945), "pane destruction should remove sidecar")
+  assert(attention.get_attention(945) == nil, "pane destruction should clear cache")
+end)
+
+test("TTL cleanup removes canonical marker and acknowledgement sidecar", function()
+  local file = assert(io.open(test_dir .. "/946", "w"))
+  file:write('{"type":"notify","revision":"generation-g","updated_at_ms":1000000000000,"ttl_ms":1000}')
+  file:close()
+  local w = window_double({ tabs = { { 940, 946 } }, focused = true, active_pane_id = 946 })
+  attention.poll(w, { now_ms = 1000000000000 })
+  assert(acknowledgement_exists(946), "precondition: sidecar exists")
+
+  attention.poll(
+    window_double({ tabs = { { 940, 946 } }, focused = false }),
+    { now_ms = 1000000001001 })
+
+  assert(not marker_exists(946), "expired canonical marker should be removed")
+  assert(not acknowledgement_exists(946), "TTL cleanup should remove sidecar")
+  assert(attention.get_attention(946) == nil, "expired attention should leave cache")
+end)
+
+test("a stale update-status pane is never destructive authority", function()
+  write_marker(951, "notify", "generation-g")
+  local w = window_double({ tabs = { { 951, 952 } }, focused = true, active_pane_id = 952 })
+
+  attention.poll(w, { active_pane = mux_pane(951) })
+
+  assert(marker_exists(951), "the stale event pane's marker must remain")
+  assert(not acknowledgement_exists(951), "the stale event pane must not be acknowledged")
+  assert(attention.get_attention(951) == "notify", "the unseen notification must remain visible")
+end)
+
+test("acknowledgement never deletes a newer non-clearable marker", function()
+  write_marker(501, "stop", "generation-g")
   write_marker(502, "notify")
-  poll({ 501, 502 })
 
-  -- A new turn starts after poll() cached stop but before title rendering.
-  write_marker(501, "thinking")
-  format_tab_title(tab(501, 502, true))
+  local rewrote = false
+  poll_focused({
+    tabs = { { 501, 502 } },
+    active_pane_id = 501,
+    on_focus_check = function()
+      if rewrote then return end
+      rewrote = true
+      -- The poll has already cached generation G. Replace it before current
+      -- active-pane acknowledgement reads physical truth.
+      write_marker(501, "thinking", "generation-h")
+    end,
+  })
 
-  assert(marker_exists(501), "newer thinking marker should remain on disk")
-  assert(attention.get_attention(501) == "thinking", "cache should adopt the newer marker")
+  assert(marker_exists(501), "the newer thinking marker should remain on disk")
+  assert(attention.get_attention(501) == "thinking", "the cache should adopt the newer marker")
+  assert(not acknowledgement_exists(501), "a non-clearable replacement must not be acknowledged")
+end)
+
+test("a focused window with no active pane acknowledges nothing", function()
+  write_marker(821, "notify")
+
+  local w = poll_focused({ tabs = { { 821 } }, active_pane_id = nil })
+
+  assert(marker_exists(821), "with no active pane there is nothing to acknowledge")
+  assert(attention.get_attention(821) == "notify", "the cache should still be filled")
+  assert(#w.actions == 0, "there is no pane to perform an action through")
+end)
+
+-- ── U2: focus-safe redraw ───────────────────────────────────────────────────
+
+test("a focused visible change requests exactly one redraw through the active pane", function()
+  write_marker(831, "thinking")
+
+  local w = poll_focused({ tabs = { { 830, 831 } }, active_pane_id = 830 })
+
+  assert(#w.actions == 1, "one visible change should cost one action, got " .. #w.actions)
+  assert(w.actions[1].action.ActivateTabRelative == 0,
+    "the action must re-activate the current tab, changing no selection")
+  assert(w.actions[1].pane_id == 830, "the action must run through the active pane")
+  assert(#w.status_writes == 0 and #w.title_writes == 0,
+    "redrawing must not write status or title text")
+end)
+
+test("an unchanged tab bar requests no redraw", function()
+  write_marker(841, "thinking")
+  poll({ 840, 841 })
+
+  -- Pin the frame so the animation cannot manufacture a visible change.
+  local before_frame = select(2, attention.get_attention(841))
+  local file = assert(io.open(test_dir .. "/841", "w"))
+  file:write(string.format('{"type":"thinking","frame":%d}', before_frame))
+  file:close()
+  poll({ 840, 841 })
+
+  local w = poll_focused({ tabs = { { 840, 841 } }, active_pane_id = 840 })
+
+  assert(#w.actions == 0, "nothing visible changed, so nothing should be redrawn")
+end)
+
+test("a change hidden behind a higher-priority pane requests no redraw", function()
+  write_marker(851, "notify")
+  write_marker(852, "notify")
+  poll({ 850, 851, 852 })
+
+  -- 852 falls from notify to stop; 851 still shows notify, so the tab does not
+  -- change. 850 is the active pane and carries no marker, so nothing is
+  -- acknowledged either.
+  write_marker(852, "stop")
+  local w = poll_focused({ tabs = { { 850, 851, 852 } }, active_pane_id = 850 })
+
+  assert(#w.actions == 0, "a masked change should not cost a redraw, got " .. #w.actions)
+  assert(attention.get_attention(852) == "stop", "the cache should still have followed the marker")
+end)
+
+test("a marker disappearing requests a redraw", function()
+  write_marker(861, "notify")
+  poll({ 860, 861 })
+
+  os.remove(test_dir .. "/861")
+  local w = poll_focused({ tabs = { { 860, 861 } }, active_pane_id = 860 })
+
+  assert(attention.get_attention(861) == nil, "the cache should drop the removed marker")
+  assert(#w.actions == 1, "attention vanishing is a visible change, got " .. #w.actions)
+end)
+
+test("animation redraws once per wall-clock bucket, not once per poll", function()
+  write_marker(871, "thinking")
+
+  local w = window_double({ tabs = { { 870, 871 } }, focused = true, active_pane_id = 870 })
+  attention.poll(w, { now_ms = 1000 })
+  assert(#w.actions == 1, "the marker appearing is the first visible change")
+
+  attention.poll(w, { now_ms = 1000 })
+  attention.poll(w, { now_ms = 1999 })
+  assert(#w.actions == 1, "induced polls in one bucket must not redraw again")
+
+  attention.poll(w, { now_ms = 2000 })
+  assert(#w.actions == 2, "the next bucket is a new indicator, so one new redraw")
+  assert(select(2, attention.get_attention(871)) == 2, "the frame should come from the new bucket")
+end)
+
+test("redraw-induced polls terminate inside the current frame bucket", function()
+  write_marker(873, "thinking")
+
+  local reentries = 0
+  local current_now = 1000
+  local w = window_double({
+    tabs = { { 870, 873 } },
+    focused = true,
+    active_pane_id = 870,
+    on_action = function(window)
+      for _ = 1, 2 do
+        reentries = reentries + 1
+        attention.poll(window, { now_ms = current_now })
+      end
+    end,
+  })
+
+  attention.poll(w, { now_ms = 1000 })
+  assert(reentries == 2, "the compatibility action should induce two nested polls in this double")
+  assert(w.action_calls == 1, "neither nested poll may request another action")
+
+  current_now = 2000
+  attention.poll(w, { now_ms = current_now })
+  assert(reentries == 4 and w.action_calls == 2,
+    "the next bucket should permit exactly one more action")
+end)
+
+test("the per-window redraw budget caps feedback and logs once", function()
+  local w = window_double({ tabs = { { 870, 872 } }, focused = true, active_pane_id = 870 })
+  for i = 1, 8 do
+    if i % 2 == 1 then
+      write_marker(872, "notify")
+    else
+      os.remove(test_dir .. "/872")
+    end
+    attention.poll(w, { now_ms = 1000 })
+  end
+
+  assert(#w.actions == 4, "the default budget permits four redraws, got " .. #w.actions)
+  local errors = drain_errors()
+  assert(#errors == 1 and errors[1]:find("budget exhausted", 1, true),
+    "budget refusal should log once, got " .. tostring(errors[1]))
+end)
+
+test("a failed redraw action leaves marker and cache truth intact", function()
+  write_marker(881, "notify")
+
+  local w = poll_focused({
+    tabs           = { { 880, 881 } },
+    active_pane_id = 880,
+    action_error   = "wezterm exploded",
+  })
+
+  assert(#w.actions == 0, "the failed action should record nothing")
+  assert(marker_exists(881), "a failed redraw must not touch the marker")
+  assert(attention.get_attention(881) == "notify", "a failed redraw must not touch the cache")
+
+  local errors = drain_errors()
+  assert(#errors == 1 and errors[1]:find("redraw failed", 1, true),
+    "the failure should be logged once, got " .. tostring(errors[1]))
+
+  write_marker(881, "stop")
+  attention.poll(w, { now_ms = 2000 })
+  assert(w.action_calls == 1, "a failed window should not retry the compatibility action")
+  assert(#drain_errors() == 0, "a disabled window should not repeat the runtime error")
+end)
+
+test("a build without perform_action skips the redraw and mutates nothing", function()
+  write_marker(891, "notify")
+
+  local w = poll_focused({
+    tabs           = { { 890, 891 } },
+    active_pane_id = 890,
+    omit           = { perform_action = true },
+  })
+
+  assert(marker_exists(891), "an unsupported redraw must not touch the marker")
+  assert(attention.get_attention(891) == "notify", "the cache should still be correct")
+  assert(#w.status_writes == 0 and #w.title_writes == 0,
+    "status and title are never a fallback for a missing redraw API")
+
+  local errors = drain_errors()
+  assert(#errors == 1 and errors[1]:find("perform_action", 1, true),
+    "the missing method should be reported once, got " .. tostring(errors[1]))
+end)
+
+-- ── U2: window scoping and composition root ─────────────────────────────────
+
+test("polling one window never removes another window's cache entries", function()
+  write_marker(901, "thinking")
+  write_marker(902, "thinking")
+
+  poll_focused({ tabs = { { 901 } }, active_pane_id = 901 })
+  assert(attention.get_attention(901) == "thinking", "window A's pane should be cached")
+
+  poll_focused({ tabs = { { 902 } }, active_pane_id = 902 })
+  assert(attention.get_attention(901) == "thinking", "window A's entry must survive window B's poll")
+  assert(attention.get_attention(902) == "thinking", "window B's pane should be cached")
+end)
+
+test("poll resolves current pane even when the event pane is supplied", function()
+  write_marker(911, "notify", "generation-g")
+
+  local w = window_double({ tabs = { { 911 } }, focused = true, active_pane_id = 911 })
+  attention.poll(w, { active_pane = mux_pane(911) })
+
+  assert(w.active_pane_calls == 1, "destructive authority must be resolved at use time")
+  assert(marker_exists(911), "acknowledgement must retain canonical writer truth")
+  assert(acknowledgement_exists(911), "the current active pane should be acknowledged")
+end)
+
+test("the registered update-status handler resolves current pane before acknowledgement", function()
+  -- A second, independent copy of the plugin: apply_to_config only registers
+  -- handlers once per module instance.
+  local second = dofile(repo_root .. "/plugin/init.lua")
+  second.apply_to_config({}, { dir = test_dir, review_key = false })
+
+  local update_status = handlers["update-status"][#handlers["update-status"]]
+  write_marker(921, "notify", "generation-g")
+
+  local w = window_double({ tabs = { { 921 } }, focused = true, active_pane_id = 921 })
+  update_status(w, mux_pane(921))
+
+  assert(w.active_pane_calls == 1, "the handler must not trust its captured event pane")
+  assert(marker_exists(921), "the canonical marker should remain")
+  assert(acknowledgement_exists(921), "the current active pane should be acknowledged")
+end)
+
+test("review toggles redraw only when the affected tab projection changes", function()
+  local review = dofile(repo_root .. "/plugin/init.lua")
+  local config = {}
+  review.apply_to_config(config, { auto_poll = false, dir = test_dir })
+  local toggle = assert(config.keys and config.keys[1] and config.keys[1].action,
+    "review key action was not registered")
+
+  write_marker(971, "notify", "notify-971")
+  write_marker(972, "review", "review-972")
+  local masked = window_double({ tabs = { { 971, 972 } }, focused = true, active_pane_id = 972 })
+  review.poll(window_double({ tabs = { { 971, 972 } }, focused = false }), { now_ms = 1000 })
+  toggle(masked, mux_pane(972))
+  assert(not marker_exists(972), "the review marker should still be removed")
+  assert(masked.action_calls == 0, "notify still wins, so the tab did not visibly change")
+
+  write_marker(973, "review", "review-973")
+  local visible = window_double({ tabs = { { 973 } }, focused = true, active_pane_id = 973 })
+  review.poll(window_double({ tabs = { { 973 } }, focused = false }), { now_ms = 1000 })
+  toggle(visible, mux_pane(973))
+  assert(not marker_exists(973), "the visible review marker should be removed")
+  assert(visible.action_calls == 1, "removing visible review attention should redraw once")
+
+  write_marker(974, "notify", "notify-974")
+  local acknowledged = window_double({ tabs = { { 974 } }, focused = true, active_pane_id = 974 })
+  review.poll(acknowledged, { now_ms = 2000 })
+  assert(acknowledgement_exists(974), "precondition: notify is acknowledged")
+  toggle(acknowledged, mux_pane(974))
+  local marker = assert(io.open(test_dir .. "/974", "r"))
+  local marker_bytes = marker:read("*a")
+  marker:close()
+  assert(marker_bytes:find('"type":"notify"', 1, true),
+    "review must not overwrite acknowledged writer truth")
+
+  local review_path = test_dir .. "/975"
+  local real_rename = os.rename
+  os.rename = function(from, to)
+    if to == review_path then return nil, "permission denied" end
+    return real_rename(from, to)
+  end
+  local failed = window_double({ tabs = { { 975 } }, focused = true, active_pane_id = 975 })
+  local ok, toggle_err = pcall(toggle, failed, mux_pane(975))
+  os.rename = real_rename
+  assert(ok, "review rename failure should be contained: " .. tostring(toggle_err))
+  assert(not marker_exists(975), "failed review publication must not create canonical state")
+  assert(not path_exists(review_path .. ".tmp"), "failed review publication must remove its temp")
+  local errors = drain_errors()
+  assert(#errors == 1 and errors[1]:find("failed to place review marker", 1, true),
+    "the real review rename failure should be logged")
 end)
 
 os.execute("rm -rf " .. shell_quote(test_dir))

--- a/tests/auto_clear_spec.lua
+++ b/tests/auto_clear_spec.lua
@@ -38,7 +38,7 @@ local wezterm = {
       updated_at = tonumber(content:match('"updated_at"%s*:%s*(%d+)')),
       updated_at_ms = tonumber(content:match('"updated_at_ms"%s*:%s*(%d+)')),
       ttl_ms = tonumber(content:match('"ttl_ms"%s*:%s*(%d+)')),
-      revision = content:match('"revision"%s*:%s*"([^"]+)"'),
+      publication_id = content:match('"publication_id"%s*:%s*"([^"]+)"'),
     }
   end,
   log_error = function(message)
@@ -73,10 +73,11 @@ local internal = assert(attention._internal, "internal seams were not exposed")
 
 -- ── Fixtures ────────────────────────────────────────────────────────────────
 
-local function write_marker(pane_id, marker_type, revision)
+local function write_marker(pane_id, marker_type, publication_id)
   local file = assert(io.open(test_dir .. "/" .. pane_id, "w"))
-  if revision then
-    file:write(string.format('{"type":"%s","revision":"%s"}', marker_type, revision))
+  if publication_id then
+    file:write(string.format(
+      '{"type":"%s","publication_id":"%s"}', marker_type, publication_id))
   else
     file:write(string.format('{"type":"%s"}', marker_type))
   end
@@ -373,9 +374,9 @@ test("time-derived frames preserve the public get_attention return shape", funct
   assert(frame == 3, "the second return remains the derived frame, got " .. tostring(frame))
 end)
 
-test("Lua accepts the revision-bearing marker shape published by Pi", function()
+test("Lua accepts the publication ID marker shape published by Pi", function()
   local file = assert(io.open(test_dir .. "/733", "w"))
-  file:write('{"type":"notify","source":"pi","revision":"pi-generation",'
+  file:write('{"type":"notify","source":"pi","publication_id":"pi-publication",'
     .. '"updated_at":1000,"label":"done","unknown":"ignored"}')
   file:close()
 
@@ -384,7 +385,7 @@ test("Lua accepts the revision-bearing marker shape published by Pi", function()
     { now_ms = 1000000 })
 
   assert(attention.get_attention(733) == "notify",
-    "Pi's revision and extra fields must not change the marker type")
+    "Pi's publication ID and extra fields must not change the marker type")
 end)
 
 test("a coarse clock clamps generated frames to one-second buckets", function()
@@ -530,16 +531,16 @@ test("visiting the sibling pane acknowledges its retained marker", function()
   assert(attention.get_attention(402) == nil, "the acknowledged sibling should disappear from effective cache")
 end)
 
-test("a new marker revision releases an older acknowledgement", function()
-  write_marker(931, "notify", "generation-g")
+test("a new publication ID releases an older acknowledgement", function()
+  write_marker(931, "notify", "publication-a")
   poll_focused({ tabs = { { 930, 931 } }, active_pane_id = 931 })
-  assert(attention.get_attention(931) == nil, "generation G should be acknowledged")
+  assert(attention.get_attention(931) == nil, "publication A should be acknowledged")
 
-  write_marker(931, "notify", "generation-h")
+  write_marker(931, "notify", "publication-b")
   poll({ 930, 931 })
 
-  assert(attention.get_attention(931) == "notify", "generation H must be visible")
-  assert(not acknowledgement_exists(931), "the stale generation-G acknowledgement should be removed")
+  assert(attention.get_attention(931) == "notify", "publication B must be visible")
+  assert(not acknowledgement_exists(931), "the stale publication-A acknowledgement should be removed")
 end)
 
 test("legacy raw identity remains compatible and changed bytes become visible", function()
@@ -555,8 +556,8 @@ test("legacy raw identity remains compatible and changed bytes become visible", 
 end)
 
 test("a stale acknowledgement never suppresses mismatched canonical truth when cleanup fails", function()
-  write_marker(933, "notify", "generation-h")
-  write_acknowledgement_file(933, "revision\ngeneration-g")
+  write_marker(933, "notify", "publication-b")
+  write_acknowledgement_file(933, "publication\npublication-a")
 
   local ack_path = test_dir .. "/933.ack"
   local real_remove = os.remove
@@ -575,7 +576,7 @@ test("a stale acknowledgement never suppresses mismatched canonical truth when c
 end)
 
 test("canonical absence clears acknowledgement without resurrecting state", function()
-  write_marker(941, "stop", "generation-g")
+  write_marker(941, "stop", "publication-a")
   poll_focused({ tabs = { { 940, 941 } }, active_pane_id = 941 })
   assert(acknowledgement_exists(941), "the sidecar should exist after acknowledgement")
 
@@ -587,7 +588,7 @@ test("canonical absence clears acknowledgement without resurrecting state", func
 end)
 
 test("direct disk reads respect acknowledgement identity", function()
-  write_marker(942, "notify", "generation-g")
+  write_marker(942, "notify", "publication-a")
   poll_focused({ tabs = { { 940, 942 } }, active_pane_id = 942 })
 
   assert(attention.get_attention(942, { dir = test_dir }) == nil,
@@ -595,7 +596,7 @@ test("direct disk reads respect acknowledgement identity", function()
 end)
 
 test("acknowledgement survives a plugin reload without moving canonical truth", function()
-  write_marker(947, "notify", "generation-g")
+  write_marker(947, "notify", "publication-a")
   poll_focused({ tabs = { { 940, 947 } }, active_pane_id = 947 })
   assert(acknowledgement_exists(947), "precondition: sidecar exists")
 
@@ -608,7 +609,7 @@ test("acknowledgement survives a plugin reload without moving canonical truth", 
 end)
 
 test("acknowledgement write failure leaves marker visible and cache truthful", function()
-  write_marker(943, "notify", "generation-g")
+  write_marker(943, "notify", "publication-a")
   poll({ 943 })
 
   local outcome = internal.acknowledge_focused_pane(943, {
@@ -624,7 +625,7 @@ test("acknowledgement write failure leaves marker visible and cache truthful", f
 end)
 
 test("acknowledgement rename failure removes its temp and leaves truth visible", function()
-  write_marker(948, "notify", "generation-g")
+  write_marker(948, "notify", "publication-a")
   poll({ 948 })
 
   local ack_path = test_dir .. "/948.ack"
@@ -650,7 +651,7 @@ test("acknowledgement rename failure removes its temp and leaves truth visible",
 end)
 
 test("public removal clears canonical marker and acknowledgement sidecar", function()
-  write_marker(944, "stop", "generation-g")
+  write_marker(944, "stop", "publication-a")
   poll_focused({ tabs = { { 940, 944 } }, active_pane_id = 944 })
   assert(acknowledgement_exists(944), "precondition: sidecar exists")
 
@@ -662,7 +663,7 @@ test("public removal clears canonical marker and acknowledgement sidecar", funct
 end)
 
 test("pane destruction clears canonical marker and acknowledgement sidecar", function()
-  write_marker(945, "notify", "generation-g")
+  write_marker(945, "notify", "publication-a")
   poll_focused({ tabs = { { 940, 945 } }, active_pane_id = 945 })
   assert(acknowledgement_exists(945), "precondition: sidecar exists")
 
@@ -675,7 +676,8 @@ end)
 
 test("TTL cleanup removes canonical marker and acknowledgement sidecar", function()
   local file = assert(io.open(test_dir .. "/946", "w"))
-  file:write('{"type":"notify","revision":"generation-g","updated_at_ms":1000000000000,"ttl_ms":1000}')
+  file:write('{"type":"notify","publication_id":"publication-a",'
+    .. '"updated_at_ms":1000000000000,"ttl_ms":1000}')
   file:close()
   local w = window_double({ tabs = { { 940, 946 } }, focused = true, active_pane_id = 946 })
   attention.poll(w, { now_ms = 1000000000000 })
@@ -691,7 +693,7 @@ test("TTL cleanup removes canonical marker and acknowledgement sidecar", functio
 end)
 
 test("a stale update-status pane is never destructive authority", function()
-  write_marker(951, "notify", "generation-g")
+  write_marker(951, "notify", "publication-a")
   local w = window_double({ tabs = { { 951, 952 } }, focused = true, active_pane_id = 952 })
 
   attention.poll(w, { active_pane = mux_pane(951) })
@@ -702,7 +704,7 @@ test("a stale update-status pane is never destructive authority", function()
 end)
 
 test("acknowledgement never deletes a newer non-clearable marker", function()
-  write_marker(501, "stop", "generation-g")
+  write_marker(501, "stop", "publication-a")
   write_marker(502, "notify")
 
   local rewrote = false
@@ -712,9 +714,9 @@ test("acknowledgement never deletes a newer non-clearable marker", function()
     on_focus_check = function()
       if rewrote then return end
       rewrote = true
-      -- The poll has already cached generation G. Replace it before current
+      -- The poll has already cached publication A. Replace it before current
       -- active-pane acknowledgement reads physical truth.
-      write_marker(501, "thinking", "generation-h")
+      write_marker(501, "thinking", "publication-b")
     end,
   })
 
@@ -907,7 +909,7 @@ test("polling one window never removes another window's cache entries", function
 end)
 
 test("poll resolves current pane even when the event pane is supplied", function()
-  write_marker(911, "notify", "generation-g")
+  write_marker(911, "notify", "publication-a")
 
   local w = window_double({ tabs = { { 911 } }, focused = true, active_pane_id = 911 })
   attention.poll(w, { active_pane = mux_pane(911) })
@@ -924,7 +926,7 @@ test("the registered update-status handler resolves current pane before acknowle
   second.apply_to_config({}, { dir = test_dir, review_key = false })
 
   local update_status = handlers["update-status"][#handlers["update-status"]]
-  write_marker(921, "notify", "generation-g")
+  write_marker(921, "notify", "publication-a")
 
   local w = window_double({ tabs = { { 921 } }, focused = true, active_pane_id = 921 })
   update_status(w, mux_pane(921))

--- a/tests/pi_extension.test.ts
+++ b/tests/pi_extension.test.ts
@@ -99,7 +99,7 @@ test("lifecycle: agent_start writes a thinking marker with ttl_ms, updated_at, s
 	const m = readMarker(dir);
 	expect(m.type).toBe("thinking");
 	expect(m.source).toBe("pi");
-	expect(typeof m.revision).toBe("string");
+	expect(typeof m.publication_id).toBe("string");
 	expect(typeof m.ttl_ms).toBe("number");
 	expect(typeof m.updated_at).toBe("number"); // locks the contract field bun won't typecheck
 });
@@ -182,15 +182,15 @@ test("event: a bare string state is accepted", async () => {
 	expect(readMarker(dir).type).toBe("review");
 });
 
-test("publication: identical states receive distinct revisions", async () => {
-	const dir = freshDir("wez-revision-");
+test("publication: identical states receive distinct publication IDs", async () => {
+	const dir = freshDir("wez-publication-");
 	process.env.WEZTERM_PANE = "42";
 	const { emit } = loadExt();
 
 	await emit("notify");
-	const first = readMarker(dir).revision;
+	const first = readMarker(dir).publication_id;
 	await emit("notify");
-	const second = readMarker(dir).revision;
+	const second = readMarker(dir).publication_id;
 
 	expect(typeof first).toBe("string");
 	expect(typeof second).toBe("string");

--- a/tests/pi_extension.test.ts
+++ b/tests/pi_extension.test.ts
@@ -99,6 +99,7 @@ test("lifecycle: agent_start writes a thinking marker with ttl_ms, updated_at, s
 	const m = readMarker(dir);
 	expect(m.type).toBe("thinking");
 	expect(m.source).toBe("pi");
+	expect(typeof m.revision).toBe("string");
 	expect(typeof m.ttl_ms).toBe("number");
 	expect(typeof m.updated_at).toBe("number"); // locks the contract field bun won't typecheck
 });
@@ -179,6 +180,21 @@ test("event: a bare string state is accepted", async () => {
 	const { emit } = loadExt();
 	await emit("review");
 	expect(readMarker(dir).type).toBe("review");
+});
+
+test("publication: identical states receive distinct revisions", async () => {
+	const dir = freshDir("wez-revision-");
+	process.env.WEZTERM_PANE = "42";
+	const { emit } = loadExt();
+
+	await emit("notify");
+	const first = readMarker(dir).revision;
+	await emit("notify");
+	const second = readMarker(dir).revision;
+
+	expect(typeof first).toBe("string");
+	expect(typeof second).toBe("string");
+	expect(second).not.toBe(first);
 });
 
 test("ordering: notify then clear leaves NO marker (last requested wins)", async () => {


### PR DESCRIPTION
## Summary

Fixes the inactive-tab redraw failure reported in #4 without taking ownership of left/right status or window titles. Marker changes now trigger a focused, same-tab redraw only when the rendered attention projection changes, while wall-clock animation frames prevent redraw-induced polling from feeding itself.

Focus acknowledgement is also made non-destructive: the plugin records the exact marker identity in an acknowledgement sidecar instead of deleting writer-owned state. New publication IDs remain visible, legacy markers remain compatible, and current-pane and zoomed-pane semantics stay aligned with the renderer.

## Key changes

- **Visible-change redraw**: Compare indicator, type, and color before requesting `ActivateTabRelative(0)`; ignore changes hidden by a higher-priority sibling.
- **Loop-safe animation**: Derive generated thinking frames from wall-clock buckets and cap poll-triggered redraws per focused window.
- **Non-destructive acknowledgement**: Store `<pane>.ack` identity sidecars; never move or delete the canonical marker during focus acknowledgement.
- **Fresh publication identity**: Add unique `publication_id` values to Pi, shell, TypeScript, Claude, and Codex writer examples while preserving raw-byte identity for legacy markers.
- **Current-state authority**: Resolve `window:active_pane()` at use time, keep inactive sibling attention, and match GUI zoom projection through `panes_with_info()`.
- **Failure containment**: Log redraw failures once per window, bind the coarse clock after a high-resolution clock failure, and clean failed acknowledgement/review temporary files.
- **Status preservation**: The plugin never calls `set_left_status`, `set_right_status`, or `set_title` as a redraw mechanism.

## Why this differs from #4

#4 correctly identified that changing the Lua cache does not make stable WezTerm re-run inactive tab title formatting. Its proposed zero-width status mutation would overwrite user-owned status and its poll-count spinner could sustain the redraw events it induced. This version keeps the diagnosis and replaces the mechanism.

## Verification

- [x] `luajit tests/auto_clear_spec.lua` — 43 passed, 0 failed
- [x] `bun test` — 24 passed, 0 failed
- [x] `bash -n examples/hook.sh` and `zsh -n examples/hook.sh`
- [x] `git diff --check`
- [x] 1,000 external update/clear/ack cycles — 0 lost canonical publications, 0 false suppressions, 0 stale sidecars
- [x] 1,000 shell fallback publication IDs — 1,000 unique, 0 empty
- [x] Installed WezTerm focused-window probe — four redraws with unchanged selection/title and zero captured focus bytes

## Related

Supersedes #4 (closed; no Linear ticket).
