### PR TITLE
fix: close post-merge attention races

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,9 @@ No background threads, no FFI, no external dependencies — just filesystem read
 - `status_update_interval` defaults to 1000ms; markers update on this interval. Lower it if indicators feel slow — the redraw request rides on the same tick.
 
 **Indicators appear only when you switch tabs?**
-- The redraw needs `window:is_focused()`, `window:active_pane()`, and `window:perform_action()`. On a build missing any of them the plugin logs once to the WezTerm error log and falls back to WezTerm's own redraw timing.
+- Without `window:is_focused()`, the plugin cannot safely acknowledge attention or request a compatibility redraw.
+- Without `window:active_pane()`, acknowledgement is disabled, but redraw can still use the pane supplied by `update-status`.
+- Without `window:perform_action()`, acknowledgement and polling continue, but inactive tabs update only on ordinary WezTerm redraws.
 - In `renderer = "manual"` mode, pass the event pane: `attention.poll(window, { active_pane = pane })`. The plugin resolves `window:active_pane()` at use time; the event pane is used only when the current pane is unavailable.
 
 **Tab titles look wrong?**

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -506,6 +506,7 @@ local redraw_budget = {}
 local redraw_budget_reported = false
 local redraw_disabled = {}
 local redraw_pending = {}
+local redraw_in_flight = {}
 
 local function report_missing_once(method_name, impact)
   if reported_missing[method_name] then return end
@@ -757,14 +758,23 @@ function M.poll(window, opts)
   end
 
   local window_key = redraw_window_key(window)
+  if redraw_in_flight[window_key] then
+    if changed then redraw_pending[window_key] = true end
+    return
+  end
+
   local needs_redraw = changed or redraw_pending[window_key]
   if needs_redraw then
     if redraw_disabled[window_key] then
       redraw_pending[window_key] = nil
     elseif redraw_allowed(window, now) then
-      if request_tab_bar_redraw(window, action_pane) or redraw_disabled[window_key] then
+      redraw_pending[window_key] = nil
+      redraw_in_flight[window_key] = true
+      local succeeded = request_tab_bar_redraw(window, action_pane)
+      redraw_in_flight[window_key] = nil
+      if redraw_disabled[window_key] then
         redraw_pending[window_key] = nil
-      else
+      elseif not succeeded then
         redraw_pending[window_key] = true
       end
     else

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -505,6 +505,7 @@ local reported_missing = {}
 local redraw_budget = {}
 local redraw_budget_reported = false
 local redraw_disabled = {}
+local redraw_pending = {}
 
 local function report_missing_once(method_name)
   if reported_missing[method_name] then return end
@@ -749,8 +750,20 @@ function M.poll(window, opts)
     end
   end
 
-  if changed and redraw_allowed(window, now) then
-    request_tab_bar_redraw(window, action_pane)
+  local window_key = redraw_window_key(window)
+  local needs_redraw = changed or redraw_pending[window_key]
+  if needs_redraw then
+    if redraw_disabled[window_key] then
+      redraw_pending[window_key] = nil
+    elseif redraw_allowed(window, now) then
+      if request_tab_bar_redraw(window, action_pane) or redraw_disabled[window_key] then
+        redraw_pending[window_key] = nil
+      else
+        redraw_pending[window_key] = true
+      end
+    else
+      redraw_pending[window_key] = true
+    end
   end
 end
 

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -432,7 +432,7 @@ end
 --- acknowledged while its window is in the background is a notification the user
 --- never saw.
 ---
-local function cache_marker_values(id, atype, frame, raw, observed_now)
+local function cache_marker_values(id, atype, frame, raw, publication_id, observed_now)
   if not atype then
     attention_cache[id] = nil
     return
@@ -449,6 +449,7 @@ local function cache_marker_values(id, atype, frame, raw, observed_now)
     frame       = frame,
     observed_at = observed_now,
     raw         = raw,
+    identity    = marker_identity(publication_id, raw),
   }
 end
 
@@ -468,23 +469,31 @@ local function acknowledge_focused_pane(pane_id, opts)
     return "absent"
   end
 
+  local current_identity = marker_identity(publication_id, raw)
+  if cached.identity ~= current_identity then
+    cache_marker_values(id, current_type, current_frame, raw, publication_id, observed_now)
+    return "kept"
+  end
+
   if not acknowledge_set[current_type] then
     clear_acknowledgement(dir, id)
-    cache_marker_values(id, current_type, current_frame, raw, observed_now)
+    cache_marker_values(id, current_type, current_frame, raw, publication_id, observed_now)
     return "kept"
   end
 
   local write_ack = (opts and opts.write_acknowledgement) or write_acknowledgement
-  if not write_ack(dir, id, marker_identity(publication_id, raw)) then
-    cache_marker_values(id, current_type, current_frame, raw, observed_now)
+  if not write_ack(dir, id, current_identity) then
+    cache_marker_values(id, current_type, current_frame, raw, publication_id, observed_now)
     return "failed"
   end
 
   -- A writer may replace or clear the marker while the sidecar is being
   -- written. Re-read effective truth before updating the cache: only the exact
   -- identity that was viewed is suppressed.
-  local effective_type, effective_frame, _, _, effective_raw = read_effective_marker(dir, id)
-  cache_marker_values(id, effective_type, effective_frame, effective_raw, observed_now)
+  local effective_type, effective_frame, _, _, effective_raw, effective_publication_id =
+    read_effective_marker(dir, id)
+  cache_marker_values(
+    id, effective_type, effective_frame, effective_raw, effective_publication_id, observed_now)
   return effective_type and "kept" or "acknowledged"
 end
 
@@ -704,6 +713,7 @@ function M.poll(window, opts)
             frame       = frame,
             observed_at = observed_at,
             raw         = raw,
+            identity    = marker_identity(publication_id, raw),
           }
         end
       else
@@ -984,6 +994,7 @@ function M.apply_to_config(config, opts)
           attention_cache[target_id] = {
             type = "review",
             raw = raw,
+            identity = marker_identity(publication_id, raw),
           }
           redraw_if_visible_changed()
         else

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -638,7 +638,7 @@ end
 
 --- Remove the attention marker for a pane.
 function M.remove_marker(pane_id, opts)
-  local dir = (opts and opts.dir) or defaults.dir
+  local dir = (opts and opts.dir) or M._active_dir or defaults.dir
   local id = tostring(pane_id)
   remove_marker(dir, id)
   attention_cache[id] = nil

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -507,12 +507,12 @@ local redraw_budget_reported = false
 local redraw_disabled = {}
 local redraw_pending = {}
 
-local function report_missing_once(method_name)
+local function report_missing_once(method_name, impact)
   if reported_missing[method_name] then return end
   reported_missing[method_name] = true
   wezterm.log_error(
     "wezterm-attention: this WezTerm build does not expose window:" .. method_name ..
-    "(); inactive tabs will update only on ordinary WezTerm redraws")
+    "(); " .. impact)
 end
 
 local function redraw_window_key(window)
@@ -555,7 +555,9 @@ end
 local function window_is_focused(window)
   local is_focused = window.is_focused
   if type(is_focused) ~= "function" then
-    report_missing_once("is_focused")
+    report_missing_once(
+      "is_focused",
+      "attention acknowledgement and compatibility redraw are disabled")
     return false
   end
   local ok, focused = pcall(is_focused, window)
@@ -568,7 +570,9 @@ end
 local function window_current_active_pane(window)
   local active_pane = window.active_pane
   if type(active_pane) ~= "function" then
-    report_missing_once("active_pane")
+    report_missing_once(
+      "active_pane",
+      "attention acknowledgement is disabled; redraw can still use the update-status event pane")
     return nil
   end
   local ok, resolved = pcall(active_pane, window)
@@ -608,7 +612,9 @@ local function request_tab_bar_redraw(window, pane)
 
   local perform_action = window.perform_action
   if type(perform_action) ~= "function" then
-    report_missing_once("perform_action")
+    report_missing_once(
+      "perform_action",
+      "compatibility redraw is disabled; inactive tabs update only on ordinary WezTerm redraws")
     redraw_disabled[window_key] = true
     return false
   end

--- a/tests/auto_clear_spec.lua
+++ b/tests/auto_clear_spec.lua
@@ -662,6 +662,29 @@ test("public removal clears canonical marker and acknowledgement sidecar", funct
   assert(attention.get_attention(944) == nil, "public removal should clear cache")
 end)
 
+test("public removal without opts uses the configured marker directory", function()
+  local configured_dir = test_dir .. "/configured"
+  assert(os.execute("mkdir -p " .. shell_quote(configured_dir)) == 0)
+  local marker = assert(io.open(configured_dir .. "/949", "w"))
+  marker:write('{"type":"notify","publication_id":"publication-a"}')
+  marker:close()
+  local ack = assert(io.open(configured_dir .. "/949.ack", "w"))
+  ack:write("publication\npublication-a")
+  ack:close()
+
+  local configured = dofile(repo_root .. "/plugin/init.lua")
+  configured.apply_to_config({}, {
+    auto_poll = false,
+    dir = configured_dir,
+    review_key = false,
+  })
+  configured.remove_marker(949)
+
+  assert(not path_exists(configured_dir .. "/949"), "configured marker should be removed")
+  assert(not path_exists(configured_dir .. "/949.ack"),
+    "configured acknowledgement should be removed")
+end)
+
 test("pane destruction clears canonical marker and acknowledgement sidecar", function()
   write_marker(945, "notify", "publication-a")
   poll_focused({ tabs = { { 940, 945 } }, active_pane_id = 945 })

--- a/tests/auto_clear_spec.lua
+++ b/tests/auto_clear_spec.lua
@@ -869,6 +869,22 @@ test("the per-window redraw budget caps feedback and logs once", function()
     "budget refusal should log once, got " .. tostring(errors[1]))
 end)
 
+test("a budget-rejected final projection is retried after reset", function()
+  local w = window_double({ tabs = { { 870, 874 } }, focused = true, active_pane_id = 870 })
+  for i = 1, 5 do
+    if i % 2 == 1 then
+      write_marker(874, "notify")
+    else
+      os.remove(test_dir .. "/874")
+    end
+    attention.poll(w, { now_ms = 1000 })
+  end
+  assert(#w.actions == 4, "precondition: fifth change is budget-rejected")
+
+  attention.poll(w, { now_ms = 2000 })
+  assert(#w.actions == 5, "the final projection should redraw after the budget resets")
+end)
+
 test("a failed redraw action leaves marker and cache truth intact", function()
   write_marker(881, "notify")
 

--- a/tests/auto_clear_spec.lua
+++ b/tests/auto_clear_spec.lua
@@ -775,6 +775,41 @@ test("a focused window with no active pane acknowledges nothing", function()
   assert(#w.actions == 0, "there is no pane to perform an action through")
 end)
 
+test("a missing focus method reports acknowledgement and redraw degradation", function()
+  write_marker(822, "notify", "publication-a")
+  local w = window_double({
+    tabs = { { 822 } },
+    focused = true,
+    active_pane_id = 822,
+    omit = { is_focused = true },
+  })
+  attention.poll(w, { active_pane = mux_pane(822) })
+
+  assert(not acknowledgement_exists(822), "missing focus method must disable acknowledgement")
+  assert(w.action_calls == 0, "missing focus method must disable redraw")
+  local errors = drain_errors()
+  assert(#errors == 1 and errors[1]:find("acknowledgement and compatibility redraw are disabled", 1, true),
+    "warning should name both disabled behaviors")
+end)
+
+test("a missing active pane method retains event-pane redraw", function()
+  write_marker(823, "notify", "publication-a")
+  local w = window_double({
+    tabs = { { 823 } },
+    focused = true,
+    active_pane_id = 823,
+    omit = { active_pane = true },
+  })
+  attention.poll(w, { active_pane = mux_pane(823) })
+
+  assert(not acknowledgement_exists(823), "missing active pane method must disable acknowledgement")
+  assert(w.action_calls == 1, "event pane should still transport the redraw")
+  local errors = drain_errors()
+  assert(#errors == 1 and errors[1]:find("acknowledgement is disabled", 1, true)
+      and errors[1]:find("event pane", 1, true),
+    "warning should preserve the event-pane redraw path")
+end)
+
 -- ── U2: focus-safe redraw ───────────────────────────────────────────────────
 
 test("a focused visible change requests exactly one redraw through the active pane", function()

--- a/tests/auto_clear_spec.lua
+++ b/tests/auto_clear_spec.lua
@@ -725,6 +725,23 @@ test("acknowledgement never deletes a newer non-clearable marker", function()
   assert(not acknowledgement_exists(501), "a non-clearable replacement must not be acknowledged")
 end)
 
+test("a same-type replacement during acknowledgement remains visible", function()
+  write_marker(981, "notify", "publication-a")
+  local replaced = false
+  poll_focused({
+    tabs = { { 980, 981 } },
+    active_pane_id = 981,
+    on_focus_check = function()
+      if replaced then return end
+      replaced = true
+      write_marker(981, "notify", "publication-b")
+    end,
+  })
+
+  assert(attention.get_attention(981) == "notify", "replacement B must remain visible")
+  assert(not acknowledgement_exists(981), "replacement B must not be acknowledged unseen")
+end)
+
 test("a focused window with no active pane acknowledges nothing", function()
   write_marker(821, "notify")
 

--- a/tests/auto_clear_spec.lua
+++ b/tests/auto_clear_spec.lua
@@ -943,6 +943,32 @@ test("a budget-rejected final projection is retried after reset", function()
   assert(#w.actions == 5, "the final projection should redraw after the budget resets")
 end)
 
+test("a pending redraw retry does not re-enter before the action returns", function()
+  local current_now = 1000
+  local w = window_double({
+    tabs = { { 870, 875 } },
+    focused = true,
+    active_pane_id = 870,
+    on_action = function(window)
+      attention.poll(window, { now_ms = current_now })
+    end,
+  })
+  for i = 1, 5 do
+    if i % 2 == 1 then
+      write_marker(875, "notify")
+    else
+      os.remove(test_dir .. "/875")
+    end
+    attention.poll(w, { now_ms = current_now })
+  end
+  assert(#w.actions == 4, "precondition: fifth change is pending")
+
+  current_now = 2000
+  attention.poll(w, { now_ms = current_now })
+  assert(#w.actions == 5,
+    "the pending retry must request exactly one action, got " .. #w.actions)
+end)
+
 test("a failed redraw action leaves marker and cache truth intact", function()
   write_marker(881, "notify")
 


### PR DESCRIPTION
## Summary

Fixes four issues found after the inactive-tab redraw change merged: a same-type publication could be acknowledged before rendering, a redraw rejected by the per-second budget could be forgotten, public removal ignored the configured marker directory, and compatibility warnings overstated what remained available on older WezTerm builds.

The redraw retry also guards synchronous `perform_action` re-entry. Nested polls can record a new pending change, but cannot start another action before the current action returns.

## Key changes

- **Publication acknowledgement**: Cache the observed publication identity and acknowledge only when the confirmation read still matches it.
- **Redraw retry**: Preserve budget-rejected projections and retry after the budget resets.
- **Re-entry safety**: Consume pending state before the action and track one in-flight redraw per window.
- **Configured cleanup**: Resolve marker removal through explicit directory, configured directory, then default directory.
- **Compatibility reporting**: Document and log the separate effects of missing focus, active-pane, and action methods.

## Verification

- [x] `luajit tests/auto_clear_spec.lua` — 49 passed, 0 failed
- [x] `bun test` — 24 passed, 0 failed
- [x] `bash -n examples/hook.sh` and `zsh -n examples/hook.sh`
- [x] `git diff --check main..HEAD`
- [x] Re-entry regression reproduced before the guard: expected 5 actions, observed 8
- [x] Re-entry regression passes after the guard: exactly 5 actions

## Related

Follow-up to #5 (no Linear ticket).
